### PR TITLE
	RepositoryIterator and ReferenceIterator implementations

### DIFF
--- a/src/main/scala/tech/sourced/api/iterator/ReferenceIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/ReferenceIterator.scala
@@ -1,0 +1,36 @@
+package tech.sourced.api.iterator
+
+import org.eclipse.jgit.lib.{ObjectId, Ref, Repository}
+
+import scala.collection.JavaConverters._
+
+class ReferenceIterator(requiredColumns: Array[String], repo: Repository)
+  extends RootedRepoIterator[Ref](requiredColumns, repo) {
+
+  override protected def loadIterator(): Iterator[Ref] =
+    repo.getAllRefs.asScala.values.toIterator
+
+  override protected def mapColumns(ref: Ref): Map[String, () => Any] = {
+    val (repoId, refName) = parseRef(ref.getName)
+    Map[String, () => Any](
+      "repository_id" -> (() => {
+        repoId
+      }),
+      "name" -> (() => {
+        refName
+      }),
+      "hash" -> (() => {
+        ObjectId.toString(ref.getObjectId)
+      })
+    )
+  }
+
+  private def parseRef(ref: String): (String, String) = {
+    val split: Array[String] = ref.split("/")
+    val uuid: String = split.last
+    val repoId: String = this.getRepositoryId(uuid).get
+    val refName: String = split.init.mkString("/")
+
+    (repoId, refName)
+  }
+}

--- a/src/main/scala/tech/sourced/api/iterator/RepositoryIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/RepositoryIterator.scala
@@ -1,0 +1,25 @@
+package tech.sourced.api.iterator
+
+import org.eclipse.jgit.lib.{Repository, StoredConfig}
+
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+
+class RepositoryIterator(requiredColumns: Array[String], repo: Repository)
+  extends RootedRepoIterator[String](requiredColumns: Array[String], repo: Repository) {
+  override protected def loadIterator(): Iterator[String] =
+    repo.getConfig.getSubsections("remote").asScala.toIterator
+
+  override protected def mapColumns(uuid: String): Map[String, () => Any] = {
+    val c: StoredConfig = repo.getConfig
+    val urls: Array[String] = c.getStringList("remote", uuid, "url")
+    val isFork: Boolean = c.getBoolean("remote", uuid, "isfork", false)
+
+    Map[String, () => Any](
+      "id" -> (() => {
+        this.getRepositoryId(uuid).get
+      }),
+      "urls" -> (() => urls),
+      "is_fork" -> (() => isFork)
+    )
+  }
+}

--- a/src/main/scala/tech/sourced/api/iterator/RootedRepoIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/RootedRepoIterator.scala
@@ -1,0 +1,50 @@
+package tech.sourced.api.iterator
+
+import org.apache.spark.sql.Row
+import org.eclipse.jgit.lib.{Repository, StoredConfig}
+import tech.sourced.api.util.GitUrlsParser
+
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+
+// TODO implement filter logic
+abstract class RootedRepoIterator[T](requiredColumns: Array[String], repo: Repository) extends Iterator[Row] {
+
+  private var internalIterator: Iterator[T] = _
+
+  protected def loadIterator(): Iterator[T]
+
+  protected def mapColumns(obj: T): Map[String, () => Any]
+
+  override def hasNext: Boolean = {
+    if (internalIterator == null) {
+      internalIterator = loadIterator()
+    }
+
+    internalIterator.hasNext
+  }
+
+  override def next(): Row = {
+    val mappedValues: Map[String, () => Any] = mapColumns(internalIterator.next())
+    Row(requiredColumns.map(c => mappedValues(c)()): _*)
+  }
+
+  protected def getRepositoryId(uuid: String): Option[String] = {
+    // TODO maybe a cache here could improve performance
+    val c: StoredConfig = repo.getConfig
+    c.getSubsections("remote").asScala.find(i => i == uuid) match {
+      case None => None
+      case Some(i) => Some(GitUrlsParser.getIdFromUrls(c.getStringList("remote", i, "url")))
+    }
+  }
+
+  protected def getRepositoryUUID(id: String): Option[String] = {
+    // TODO maybe a cache here could improve performance
+    val c: StoredConfig = repo.getConfig
+    c.getSubsections("remote").asScala.find(uuid => {
+      val actualId: String =
+        GitUrlsParser.getIdFromUrls(c.getStringList("remote", uuid, "url"))
+
+      actualId == id
+    })
+  }
+}

--- a/src/main/scala/tech/sourced/api/util/GitUrlsParser.scala
+++ b/src/main/scala/tech/sourced/api/util/GitUrlsParser.scala
@@ -1,0 +1,22 @@
+package tech.sourced.api.util
+
+import java.net.{URI, URISyntaxException}
+
+import scala.util.matching.Regex
+
+object GitUrlsParser {
+  val isGit: Regex = """(.+)\\@(.+):(.+)\\.git""".r
+
+  def getIdFromUrls(urls: Array[String]): String = {
+    urls.flatMap({
+      case isGit(_, host, path, _*) => Some(host + path)
+      case s => try {
+        val u: URI = new URI(s)
+        Some(u.getHost + u.getPath)
+      } catch {
+        case _: URISyntaxException => None
+      }
+    }).distinct.min
+  }
+
+}

--- a/src/test/scala/tech/sourced/api/BaseSivaSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSivaSpec.scala
@@ -1,0 +1,5 @@
+package tech.sourced.api
+
+trait BaseSivaSpec {
+  val resourcePath: String = getClass.getResource("/siva-files").toString
+}

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -1,0 +1,20 @@
+package tech.sourced.api
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait BaseSparkSpec extends BeforeAndAfterAll {
+  this: Suite =>
+
+  var ss: SparkSession = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    ss = SparkSession.builder().appName("test").master("local[*]").getOrCreate()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    ss = null
+  }
+}

--- a/src/test/scala/tech/sourced/api/iterator/BaseRootedRepoIterator.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BaseRootedRepoIterator.scala
@@ -1,0 +1,32 @@
+package tech.sourced.api.iterator
+
+import org.apache.spark.input.PortableDataStream
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.eclipse.jgit.lib.Repository
+import org.scalatest.{Matchers, Suite}
+import tech.sourced.api.provider.{RepositoryProvider, SivaRDDProvider}
+import tech.sourced.api.{BaseSivaSpec, BaseSparkSpec}
+
+trait BaseRootedRepoIterator extends Suite with BaseSparkSpec with BaseSivaSpec with Matchers {
+  def testIterator(iterator: (Repository) => Iterator[Row], matcher: (Int, Row) => Unit, total: Int, columnsCount: Int): Unit = {
+    val prov: SivaRDDProvider = SivaRDDProvider(ss.sparkContext)
+    val rdd: RDD[PortableDataStream] = prov.get(resourcePath)
+
+    val pds: PortableDataStream = rdd.collect()(1)
+    val repo: Repository = RepositoryProvider("/tmp").get(pds)
+
+    val ri: Iterator[Row] = iterator(repo)
+
+    var count: Int = 0
+    while (ri.hasNext) {
+      val row: Row = ri.next()
+      row.length should be(columnsCount)
+      matcher(count, row)
+      count += 1
+    }
+
+    count should be(total)
+  }
+
+}

--- a/src/test/scala/tech/sourced/api/iterator/ReferenceIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/ReferenceIteratorSpec.scala
@@ -1,0 +1,43 @@
+package tech.sourced.api.iterator
+
+import org.scalatest.FlatSpec
+
+class ReferenceIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
+
+  "ReferenceIterator" should "return all references from all repositories into a siva file" in {
+    testIterator(
+      new ReferenceIterator(Array("repository_id", "name", "hash"), _), {
+        case (0, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/HEAD")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        case (1, row) =>
+          row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/HEAD")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        case (2, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/develop")
+          row.getString(2) should be("880653c14945dbbc915f1145561ed3df3ebaf168")
+        case _ =>
+      }, total = 43, columnsCount = 3
+    )
+  }
+
+  "ReferenceIterator" should "return only specified columns" in {
+    testIterator(
+      new ReferenceIterator(Array("repository_id", "name"), _), {
+        case (0, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/HEAD")
+        case (1, row) =>
+          row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/HEAD")
+        case (2, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(1) should be("refs/heads/develop")
+        case _ =>
+      }, total = 43, columnsCount = 2
+    )
+  }
+}

--- a/src/test/scala/tech/sourced/api/iterator/RepositoryIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/RepositoryIteratorSpec.scala
@@ -1,0 +1,36 @@
+package tech.sourced.api.iterator
+
+import org.scalatest.FlatSpec
+
+class RepositoryIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
+
+  "RepositoryIterator" should "return data for all repositories into a siva file" in {
+    testIterator(
+      new RepositoryIterator(Array("id", "urls", "is_fork"), _), {
+        case (0, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getAs[Array[String]](1).length should be(3)
+          row.getBoolean(2) should be(false)
+        case (1, row) =>
+          row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
+          row.getAs[Array[String]](1).length should be(3)
+          row.getBoolean(2) should be(true)
+        case (c, _) => fail(s"unexpected row number: $c")
+      }, total = 2, columnsCount = 3
+    )
+  }
+
+  "RepositoryIterator" should "return only specified columns" in {
+    testIterator(
+      new RepositoryIterator(Array("id", "is_fork"), _), {
+        case (0, row) =>
+          row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getBoolean(1) should be(false)
+        case (1, row) =>
+          row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
+          row.getBoolean(1) should be(true)
+        case (c, _) => fail(s"unexpected row number: $c")
+      }, total = 2, columnsCount = 2
+    )
+  }
+}

--- a/src/test/scala/tech/sourced/api/provider/RepositoryProviderSpec.scala
+++ b/src/test/scala/tech/sourced/api/provider/RepositoryProviderSpec.scala
@@ -1,65 +1,55 @@
 package tech.sourced.api.provider
 
-import org.apache.spark.sql.SparkSession
 import org.eclipse.jgit.lib.ObjectId
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import tech.sourced.api.{BaseSivaSpec, BaseSparkSpec}
 
 import scala.collection.JavaConverters._
 
 class RepositoryProviderSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
-  var ss: SparkSession = _
-  val resourcePath: String = getClass.getResource("/siva-files").toString
+  class RepositoryProviderSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+    "SivaRDDProvider" should "return always the same instance" in {
+      val prov = SivaRDDProvider(ss.sparkContext)
+      val prov2 = SivaRDDProvider(ss.sparkContext)
 
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    ss = SparkSession.builder().appName("test").master("local[*]").getOrCreate()
-  }
+      prov should equal(prov2)
+      prov should not equal new SivaRDDProvider(ss.sparkContext)
 
-  "SivaRDDProvider" should "return always the same instance" in {
-    val prov = SivaRDDProvider(ss.sparkContext)
-    val prov2 = SivaRDDProvider(ss.sparkContext)
-
-    prov should equal(prov2)
-    prov should not equal new SivaRDDProvider(ss.sparkContext)
-
-  }
-
-  "SivaRDDProvider" should "return the exact name of siva files" in {
-    val prov = SivaRDDProvider(ss.sparkContext)
-
-    val sivaRDD = prov.get(resourcePath)
-
-    sivaRDD.count() should be(3)
-  }
-
-  "RepositoryProvider" should "read correctly siva repositories" in {
-    val prov = SivaRDDProvider(ss.sparkContext)
-
-    val sivaRDD = prov.get(resourcePath)
-
-    val refs = sivaRDD.flatMap(pds => {
-      val repo = RepositoryProvider("/tmp").get(pds)
-
-      repo.getAllRefs.asScala.mapValues(r => ObjectId.toString(r.getPeeledObjectId))
-    }).collect()
-
-    refs.length should be(56)
-  }
-
-  "RepositoryProvider" should "fail with different local paths" in {
-    val _ = RepositoryProvider("/tmp")
-
-    val ex: RuntimeException = intercept[RuntimeException] {
-      RepositoryProvider("/tmp/two")
     }
 
-    ex.getMessage should be("actual provider instance is not intended to be used " +
-      "with the localPath provided: /tmp/two")
+    "SivaRDDProvider" should "return the exact name of siva files" in {
+      val prov = SivaRDDProvider(ss.sparkContext)
+
+      val sivaRDD = prov.get(resourcePath)
+
+      sivaRDD.count() should be(3)
+    }
+
+    "RepositoryProvider" should "read correctly siva repositories" in {
+      val prov = SivaRDDProvider(ss.sparkContext)
+
+      val sivaRDD = prov.get(resourcePath)
+
+      val refs = sivaRDD.flatMap(pds => {
+        val repo = RepositoryProvider("/tmp").get(pds)
+
+        repo.getAllRefs.asScala.mapValues(r => ObjectId.toString(r.getPeeledObjectId))
+      }).collect()
+
+      refs.length should be(56)
+    }
+
+    "RepositoryProvider" should "fail with different local paths" in {
+      val _ = RepositoryProvider("/tmp")
+
+      val ex: RuntimeException = intercept[RuntimeException] {
+        RepositoryProvider("/tmp/two")
+      }
+
+      ex.getMessage should be("actual provider instance is not intended to be used " +
+        "with the localPath provided: /tmp/two")
+    }
   }
 
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    ss = null
-  }
 }


### PR DESCRIPTION
Using a base abstract class RootedRepoIterator, we add two implementations, one of them to iterate repository metadata (repository id, urls, is fork) and references metadata (repository_id, name, hash).

With this RootedRepoIterator we should be able to implement CommitIterator and BlobIterator too.

Filter logic must be implemented before start with BlobIterator.

- Split test logic into Traits to be able to use them in all the Specs.
- Added a BaseRootedRepoIterator trait with a helper to test iterators more easly.