### PR TITLE
BlobIterator implementation

### DIFF
--- a/src/main/scala/tech/sourced/api/Implicits.scala
+++ b/src/main/scala/tech/sourced/api/Implicits.scala
@@ -32,7 +32,8 @@ object Implicits {
       Implicits.checkCols(df, "hash")
       val blobsIdsDf = df.select($"hash").distinct()
       val filesDf = Implicits.getDataSource("files", df.sparkSession)
-      filesDf.join(blobsIdsDf, filesDf("commit_hash") === df("hash")).drop($"hash")
+      val filesDfJoined = filesDf.join(blobsIdsDf, filesDf("commit_hash") === blobsIdsDf("hash")).drop($"hash")
+      df.join(filesDfJoined, df("hash") === filesDfJoined("commit_hash"))
     }
   }
 

--- a/src/main/scala/tech/sourced/api/Implicits.scala
+++ b/src/main/scala/tech/sourced/api/Implicits.scala
@@ -29,10 +29,15 @@ object Implicits {
     }
 
     def getFiles: DataFrame = {
-      Implicits.checkCols(df, "hash")
-      val commitsDf = df.drop("tree").distinct()
       val filesDf = Implicits.getDataSource("files", df.sparkSession)
-      filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
+
+      if (df.schema.fieldNames.contains("hash")) {
+        val commitsDf = df.drop("tree").distinct()
+        filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
+      } else {
+        Implicits.checkCols(df, "reference_name")
+        filesDf
+      }
     }
   }
 

--- a/src/main/scala/tech/sourced/api/Implicits.scala
+++ b/src/main/scala/tech/sourced/api/Implicits.scala
@@ -29,10 +29,10 @@ object Implicits {
     }
 
     def getFiles: DataFrame = {
-      Implicits.checkCols(df, "tree")
-      val blobsIdsDf = df.select($"blobs").distinct()
+      Implicits.checkCols(df, "hash")
+      val blobsIdsDf = df.select($"hash").distinct()
       val filesDf = Implicits.getDataSource("files", df.sparkSession)
-      filesDf.join(blobsIdsDf, array_contains(blobsIdsDf("blobs"), filesDf("file_hash"))).drop($"blobs")
+      filesDf.join(blobsIdsDf, filesDf("commit_hash") === df("hash")).drop($"hash")
     }
   }
 

--- a/src/main/scala/tech/sourced/api/Implicits.scala
+++ b/src/main/scala/tech/sourced/api/Implicits.scala
@@ -30,10 +30,9 @@ object Implicits {
 
     def getFiles: DataFrame = {
       Implicits.checkCols(df, "hash")
-      val blobsIdsDf = df.select($"hash").distinct()
+      val commitsDf = df.drop("tree").distinct()
       val filesDf = Implicits.getDataSource("files", df.sparkSession)
-      val filesDfJoined = filesDf.join(blobsIdsDf, filesDf("commit_hash") === blobsIdsDf("hash")).drop($"hash")
-      df.join(filesDfJoined, df("hash") === filesDfJoined("commit_hash"))
+      filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
     }
   }
 

--- a/src/main/scala/tech/sourced/api/Schema.scala
+++ b/src/main/scala/tech/sourced/api/Schema.scala
@@ -42,11 +42,14 @@ object Schema {
   val files = StructType(
     StructField("file_hash", StringType) ::
       StructField("content", BinaryType) ::
+      StructField("commit_hash", StringType) ::
       StructField("is_binary", BooleanType, nullable = false) ::
       StructField("path", StringType) ::
-      StructField("lang", StringType) ::
-      StructField("uast", BinaryType) ::
 
       Nil
   )
+
+  //  StructField("lang", StringType) ::
+  //  StructField("uast", BinaryType) ::
+
 }

--- a/src/main/scala/tech/sourced/api/Schema.scala
+++ b/src/main/scala/tech/sourced/api/Schema.scala
@@ -49,7 +49,4 @@ object Schema {
       Nil
   )
 
-  //  StructField("lang", StringType) ::
-  //  StructField("uast", BinaryType) ::
-
 }

--- a/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
@@ -39,9 +39,9 @@ class BlobIterator(requiredColumns: Array[String], repo: Repository, filters: Ar
       filtered
     } else {
       val refs = new Git(repo).branchList().call().asScala.filter(!_.isSymbolic)
-      println(s"Iterating all ${refs.size} refs")
+      log.warn(s"Iterating all ${refs.size} refs")
       refs.toIterator.flatMap { ref =>
-        println(s" $ref")
+        log.warn(s" $ref")
         JGitBlobIterator(getTreeWalk(ref.getObjectId), log)
       }
     }

--- a/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
@@ -1,0 +1,114 @@
+package tech.sourced.api.iterator
+
+import org.apache.log4j.Logger
+import org.eclipse.jgit.diff.RawText
+import org.eclipse.jgit.lib.{ObjectId, ObjectReader, Repository}
+import org.eclipse.jgit.revwalk.RevWalk
+import org.eclipse.jgit.treewalk.TreeWalk
+import tech.sourced.api.util.CompiledFilter
+
+/**
+  * Blob iterator: returns all blobs from the filtered commits
+  *
+  * @param requiredColumns
+  * @param repo
+  * @param filters
+  */
+class BlobIterator(requiredColumns: Array[String], repo: Repository, filters: Array[CompiledFilter])
+  extends RootedRepoIterator[TreeWalk](requiredColumns, repo) {
+
+  val log = Logger.getLogger(this.getClass.getSimpleName)
+  val readMaxBytes = 20 * 1024 * 1024
+
+  override protected def loadIterator(): Iterator[TreeWalk] = {
+    filters.flatMap { filter =>
+      filter.matchingCases.getOrElse("hash", Seq()).flatMap { hash =>
+        val commitId = ObjectId.fromString(hash.asInstanceOf[String])
+        if (repo.hasObject(commitId)) {
+          val revWalk = new RevWalk(repo)
+          val revCommit = revWalk.parseCommit(commitId)
+          revWalk.close()
+
+          val treeWalk = new TreeWalk(repo)
+          treeWalk.setRecursive(true)
+          treeWalk.addTree(revCommit.getTree)
+
+          JGitBlobIterator(treeWalk, log)
+        } else {
+          Seq()
+        }
+      }
+    }
+  }.toIterator
+
+  override protected def mapColumns(tree: TreeWalk): Map[String, () => Any] = {
+    val content = readFile(tree.getObjectId(0), tree.getObjectReader)
+    Map[String, () => Any](
+      "file_hash" -> (() => tree.getObjectId(0)),
+      "content" -> (() => content),
+      "is_binary" -> (() => RawText.isBinary(content)),
+      "path" -> (() => tree.getPathString)
+    )
+  }
+
+  /**
+    * Read max N bytes of the given blob
+    *
+    * @param objId
+    * @param reader
+    * @param max maximum number of bytes to read in memory
+    * @return
+    */
+  def readFile(objId: ObjectId, reader: ObjectReader, max: Integer = readMaxBytes): Array[Byte] = {
+    val obj = reader.open(objId)
+    val data = if (obj.isLarge) {
+      val buf = Array.ofDim[Byte](max)
+      val is = obj.openStream()
+      is.read(buf)
+      is.close()
+      buf
+    } else {
+      obj.getBytes
+    }
+    reader.close()
+    data
+  }
+
+}
+
+
+class JGitBlobIterator[T <: TreeWalk](treeWalk: T, log: Logger) extends Iterator[T] {
+  var wasAlreadyMoved = false
+
+  override def hasNext: Boolean = {
+    if (wasAlreadyMoved) {
+      return true
+    }
+
+    val hasNext = try {
+      treeWalk.next()
+    } catch {
+      case e: Exception => log.error(s"Failed to iterate tree - due to ${e.getClass.getSimpleName}", e)
+        false
+    }
+    wasAlreadyMoved = true
+    if (!hasNext) {
+      treeWalk.close()
+    }
+    hasNext
+  }
+
+  override def next(): T = {
+    if (!wasAlreadyMoved) {
+      treeWalk.next()
+    }
+    wasAlreadyMoved = false
+    treeWalk
+  }
+}
+
+object JGitBlobIterator {
+  def apply(tree: TreeWalk, log: Logger) = new JGitBlobIterator(tree, log)
+}
+
+

--- a/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
@@ -36,12 +36,12 @@ class BlobIterator(requiredColumns: Array[String], repo: Repository, filters: Ar
             filteredRefs.contains(refName)
           }
           log.debug(s"Iterating all ${refs.size} refs")
-          refs.flatMap { ref =>
+          refs.toIterator.flatMap { ref =>
             log.debug(s" $ref")
             JGitBlobIterator(getTreeWalk(ref.getObjectId), log)
           }
         case ("hash", filteredHashes) =>
-          filteredHashes.flatMap { hash =>
+          filteredHashes.toIterator.flatMap { hash =>
             val commitId = ObjectId.fromString(hash.asInstanceOf[String])
             if (repo.hasObject(commitId)) {
               JGitBlobIterator(getTreeWalk(commitId), this.log)
@@ -49,6 +49,9 @@ class BlobIterator(requiredColumns: Array[String], repo: Repository, filters: Ar
               Seq()
             }
           }
+        case anyOtherFilter =>
+          log.debug(s"BlobIterator does not support filter $anyOtherFilter")
+          Seq()
       }
 
     if (filtered.hasNext) {

--- a/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/BlobIterator.scala
@@ -49,7 +49,7 @@ class BlobIterator(requiredColumns: Array[String], repo: Repository, filters: Ar
   }
 
   override protected def mapColumns(commitTree: CommitTree): Map[String, () => Any] = {
-    log.debug(s"Reading blob: ${commitTree.tree.getObjectId(0)} of tree:${commitTree.tree.getPathString} from commit:${commitTree.commit}")
+    log.debug(s"Reading blob:${commitTree.tree.getObjectId(0).name()} of tree:${commitTree.tree.getPathString} from commit:${commitTree.commit.name()}")
     val content = BlobIterator.readFile(commitTree.tree.getObjectId(0), commitTree.tree.getObjectReader)
     val isBinary = RawText.isBinary(content)
     Map[String, () => Any](

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Define the root logger with appender
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.tech.sourced.api.iterator.BlobIterator=DEBUG

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -8,4 +8,4 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: 
 # Settings to quiet third party logs that are too verbose
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
-log4j.logger.tech.sourced.api.iterator.BlobIterator=DEBUG
+log4j.logger.tech.sourced.api.iterator.BlobIterator=INFO

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -14,6 +14,8 @@ trait BaseSparkSpec extends BeforeAndAfterAll {
       .appName("test").master("local[*]")
       .config("spark.driver.host", "localhost")
       .getOrCreate()
+
+    ss.sparkContext.setLogLevel("WARN")
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -14,8 +14,6 @@ trait BaseSparkSpec extends BeforeAndAfterAll {
       .appName("test").master("local[*]")
       .config("spark.driver.host", "localhost")
       .getOrCreate()
-
-    ss.sparkContext.setLogLevel("WARN")
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -10,7 +10,10 @@ trait BaseSparkSpec extends BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ss = SparkSession.builder().appName("test").master("local[*]").getOrCreate()
+    ss = SparkSession.builder()
+      .appName("test").master("local[*]")
+      .config("spark.driver.host", "localhost")
+      .getOrCreate()
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -24,13 +24,13 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     commitsDf.show()
 
-    // TODO files not implemented yet
-    //    val filesDf = ss.read.format("tech.sourced.api")
-    //      .option("table", "files")
-    //      .load(resourcePath)
-    //
-    //    filesDf.withColumn("content string", filesDf("content").cast(StringType)).show()
+    println("Files/blobs:\n")
+    val filesDf = ss.read.format("tech.sourced.api")
+      .option("table", "files")
+      .load(resourcePath)
 
+    filesDf.explain(true)
+    filesDf.show()
   }
 
   "Additional methods" should "work correctly" in {
@@ -47,5 +47,12 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     val commitsDf = refsDf.getCommits.select("repository_id", "reference_name", "message")
 
     commitsDf.show()
+
+    println("Files/blobs:\n")
+    val filesDf = refsDf.getCommits.getFiles
+    filesDf.explain(true)
+    filesDf.show()
   }
+
+
 }

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -24,13 +24,15 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     commitsDf.show()
 
-    println("Files/blobs:\n")
+    println("Files/blobs (without commit hash filtered) at HEAD or every ref:\n")
     val filesDf = ss.read.format("tech.sourced.api")
       .option("table", "files")
       .load(resourcePath)
 
     filesDf.explain(true)
     filesDf.show()
+
+    assert(filesDf.count() != 0)
   }
 
   "Additional methods" should "work correctly" in {
@@ -44,14 +46,18 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     val reposDf = spark.getRepositories
       .filter($"id" === "github.com/mawag/faq-xiyoulinux" || $"id" === "github.com/xiyou-linuxer/faq-xiyoulinux")
     val refsDf = reposDf.getReferences.filter($"name".equalTo("refs/heads/HEAD"))
-    val commitsDf = refsDf.getCommits.select("repository_id", "reference_name", "message")
 
-    commitsDf.show()
+    val commitsDf = refsDf.getCommits.select("repository_id", "reference_name", "message", "hash")
+    //commitsDf.show()
 
-    println("Files/blobs:\n")
-    val filesDf = refsDf.getCommits.getFiles
+    println("Files/blobs with commit hashes:\n")
+    val filesDf = refsDf.getCommits.getFiles.select("repository_id", "reference_name", "path", "commit_hash", "file_hash")
     filesDf.explain(true)
     filesDf.show()
+
+    val cnt = filesDf.count()
+    println(s"Total $cnt rows")
+    assert(cnt != 0)
   }
 
 

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -60,5 +60,24 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     assert(cnt != 0)
   }
 
+  "Convenience for getting files" should "work without commits" in {
+    val spark = ss
+    spark.sqlContext.setConf("tech.sourced.api.repositories.path", resourcePath)
+
+    import Implicits._
+    import spark.implicits._
+
+    val filesDf = ss
+      .getRepositories.filter($"id" === "github.com/mawag/faq-xiyoulinux")
+      .getReferences.filter($"name".equalTo("refs/heads/HEAD"))
+      .getFiles
+      .select("repository_id", "name", "path", "commit_hash", "file_hash", "content")
+
+    val cnt = filesDf.count()
+    info(s"Total $cnt rows")
+    assert(cnt != 0)
+
+    filesDf.show()
+  }
 
 }

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -24,7 +24,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     commitsDf.show()
 
-    println("Files/blobs (without commit hash filtered) at HEAD or every ref:\n")
+    info("Files/blobs (without commit hash filtered) at HEAD or every ref:\n")
     val filesDf = ss.read.format("tech.sourced.api")
       .option("table", "files")
       .load(resourcePath)
@@ -48,15 +48,15 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     val refsDf = reposDf.getReferences.filter($"name".equalTo("refs/heads/HEAD"))
 
     val commitsDf = refsDf.getCommits.select("repository_id", "reference_name", "message", "hash")
-    //commitsDf.show()
+    commitsDf.show()
 
-    println("Files/blobs with commit hashes:\n")
+    info("Files/blobs with commit hashes:\n")
     val filesDf = refsDf.getCommits.getFiles.select("repository_id", "reference_name", "path", "commit_hash", "file_hash")
     filesDf.explain(true)
     filesDf.show()
 
     val cnt = filesDf.count()
-    println(s"Total $cnt rows")
+    info(s"Total $cnt rows")
     assert(cnt != 0)
   }
 

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -3,11 +3,11 @@ package tech.sourced.api.iterator
 import java.nio.charset.StandardCharsets
 
 import org.scalatest.FlatSpec
-import tech.sourced.api.util.CompiledFilter
+import tech.sourced.api.util.{CompiledFilter, EqualFilter}
 
 class BlogIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
-  "BlobIterator" should "return all blobs for files at heads of all refs in repository for a siva file" in {
+  "BlobIterator" should "return all blobs for files at heads of all refs in repository" in {
     testIterator(
       new BlobIterator(
         Array(
@@ -52,6 +52,39 @@ class BlogIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
         case _ =>
 
       }, total = 433, columnsCount = 5
+    )
+  }
+
+
+  "BlobIterator" should "filter refs" in {
+    val refFilters = Array[CompiledFilter](new EqualFilter("reference_name", "refs/heads/HEAD"))
+
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, refFilters), {
+        case (0, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (1, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+
+        case (i, _) if i > 3 => fail("commits not expected")
+        case _ =>
+
+      }, total = 4, columnsCount = 5
     )
   }
 }

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -87,4 +87,21 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
       }, total = 4, columnsCount = 5
     )
   }
+
+    "BlobIterator" should "not fail with other, un-supported filters" in {
+    val filters = Array[CompiledFilter](new EqualFilter("path", "README"))
+
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, filters), {
+        case _ =>
+      }, total = 433, columnsCount = 5)
+    }
+
 }

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -1,0 +1,57 @@
+package tech.sourced.api.iterator
+
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.FlatSpec
+import tech.sourced.api.util.CompiledFilter
+
+class BlogIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
+
+  "BlobIterator" should "return all blobs for files at heads of all refs in repository for a siva file" in {
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, Array[CompiledFilter]()), {
+        case (0, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (1, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+        case (2, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (3, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+        case (4, row) =>
+          row.getString(0) should be("047b4a9cfea20a4485b5413a8771e98f7aa1a5c7")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/*")
+          row.getString(2) should be("880653c14945dbbc915f1145561ed3df3ebaf168")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be(".gitignore")
+
+        case (i, _) if i > 432 => fail("commits not expected")
+        case _ =>
+
+      }, total = 433, columnsCount = 5
+    )
+  }
+}

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import org.scalatest.FlatSpec
 import tech.sourced.api.util.{CompiledFilter, EqualFilter}
 
-class BlogIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
+class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
   "BlobIterator" should "return all blobs for files at heads of all refs in repository" in {
     testIterator(


### PR DESCRIPTION
In commit table, we have hashes of commits, which are used to get trees -> blobs.

Current implementation does not filter:
 - repository (so same blob can happen in different repository)
 - refs

It leverages `ColumnFilters` from #24 (need to be merged first) in order to get particular commit hashes, rather then iterating all refs HEADs.