### PR TITLE
[Bug] - don't merge - highlight odd behavior in SivaRDDProvider

### DIFF
--- a/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
@@ -77,6 +77,7 @@ object RepositoryProvider {
     val localSivaPath = new Path(localPath, new Path(temporalSivaFolder, remotePath.getName))
 
     // Copy siva file to local fs
+    println(s"Copy $remotePath to $localSivaPath")
     FileSystem.get(conf)
       .copyToLocalFile(remotePath, localSivaPath)
 

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -11,6 +11,7 @@ trait BaseSparkSpec extends BeforeAndAfterAll {
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     ss = SparkSession.builder().appName("test").master("local[*]").getOrCreate()
+    ss.sparkContext.setLogLevel("WARN")
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
This is a 🐛  report - it's not intended to be merged, it just includes the code that helps to expose it.

While struggling with `MissingObjectException` in #25 I noticed that if a `println` statement is added to BlobIterator - it makes exception go away, which seems to be a sign of some race conditions or copy delay.

This PR adds visibility to the .siva file copy process.

While running a **single test** `DefaultSourceSpec. "Additional methods" should "work correctly"` it
 - always prints
   ```
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva to /tmp/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva to /tmp/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva to /tmp/siva-files/05893125684f2d3943cd84a7ab2b75e53668fba1.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/fff7062de8474d10a67d417ccea87ba6f58ca81d.siva to /tmp/siva-files/fff7062de8474d10a67d417ccea87ba6f58ca81d.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/fff7062de8474d10a67d417ccea87ba6f58ca81d.siva to /tmp/siva-files/fff7062de8474d10a67d417ccea87ba6f58ca81d.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/fff840f8784ef162dc83a1465fc5763d890b68ba.siva to /tmp/siva-files/fff840f8784ef162dc83a1465fc5763d890b68ba.siva
   Copy file:~/src-d/spark-api/target/scala-2.11/test-classes/siva-files/fff840f8784ef162dc83a1465fc5763d890b68ba.siva to /tmp/siva-files/fff840f8784ef162dc83a1465fc5763d890b68ba.siva
   ```
   What seems to be a sign of excessive copy. Interesting enough, this does not happen with another test in the same spec.

 - _sometimes_ (1 out of 10 re-runs?) it crashes in a way, similar to BlobIterator.
   This stack-trace was the reason of adding more logs in particular to copy.
   ```
   17/09/10 17:35:03 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
   ExitCodeException exitCode=1: chmod: cannot access '/private/tmp/siva-files/fff840f8784ef162dc83a1465fc5763d890b68ba.siva': No such file or directory
   
   	at org.apache.hadoop.util.Shell.runCommand(Shell.java:575)
   	at org.apache.hadoop.util.Shell.run(Shell.java:478)
   	at org.apache.hadoop.util.Shell$ShellCommandExecutor.execute(Shell.java:766)
   	at org.apache.hadoop.util.Shell.execCommand(Shell.java:859)
   	at org.apache.hadoop.util.Shell.execCommand(Shell.java:842)
   	at org.apache.hadoop.fs.RawLocalFileSystem.setPermission(RawLocalFileSystem.java:661)
   	at org.apache.hadoop.fs.ChecksumFileSystem$1.apply(ChecksumFileSystem.java:501)
   	at org.apache.hadoop.fs.ChecksumFileSystem$FsOperation.run(ChecksumFileSystem.java:482)
   	at org.apache.hadoop.fs.ChecksumFileSystem.setPermission(ChecksumFileSystem.java:498)
   	at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:467)
   	at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:433)
   	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:908)
   	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:889)
   	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:786)
   	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:365)
   	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:338)
   	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:289)
   	at org.apache.hadoop.fs.LocalFileSystem.copyToLocalFile(LocalFileSystem.java:88)
   	at org.apache.hadoop.fs.FileSystem.copyToLocalFile(FileSystem.java:1917)
   	at tech.sourced.api.provider.RepositoryProvider$.tech$sourced$api$provider$RepositoryProvider$$genRepository(RepositoryProvider.scala:82)
   	at tech.sourced.api.provider.RepositoryProvider.get(RepositoryProvider.scala:28)
   	at tech.sourced.api.provider.RepositoryProvider.get(RepositoryProvider.scala:35)
   	at tech.sourced.api.GitRelation$$anonfun$buildScan$1.apply(DefaultSource.scala:49)
   	at tech.sourced.api.GitRelation$$anonfun$buildScan$1.apply(DefaultSource.scala:48)
   	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:435)
   ```

 This behavior seems to be different, if **both test** from `DefaultSourceSpec` are run together.