### PR TITLE
implicits: make SparkAPI the entrypoint instead of using an implicit

### DIFF
--- a/src/main/scala/tech/sourced/api/Implicits.scala
+++ b/src/main/scala/tech/sourced/api/Implicits.scala
@@ -7,12 +7,19 @@ import tech.sourced.api.customudf.{CustomUDF, ClassifyLanguagesUDF}
 
 object Implicits {
 
+  val repositoriesPathKey = "tech.sourced.api.repositories.path"
+
   implicit class SessionFunctions(session: SparkSession) {
     def registerUDFs(): Unit = {
       SessionFunctions.UDFtoRegister.foreach(customUDF => session.udf.register(customUDF.name, customUDF.function))
     }
 
     def getRepositories(): DataFrame = Implicits.getDataSource("repositories", session)
+
+    def setRepositoriesPath(path: String): SparkSession = {
+      session.sqlContext.setConf(Implicits.repositoriesPathKey, path)
+      session
+    }
   }
 
   object SessionFunctions {
@@ -61,7 +68,7 @@ object Implicits {
   def getDataSource(table: String, session: SparkSession): DataFrame =
     session.read.format("tech.sourced.api.DefaultSource")
       .option("table", table)
-      .load(session.sqlContext.getConf("tech.sourced.api.repositories.path"))
+      .load(session.sqlContext.getConf(repositoriesPathKey))
 
   def checkCols(df: DataFrame, cols: String*): Unit = {
     if (!df.schema.fieldNames.containsSlice(cols)) {

--- a/src/main/scala/tech/sourced/api/Schema.scala
+++ b/src/main/scala/tech/sourced/api/Schema.scala
@@ -2,7 +2,7 @@ package tech.sourced.api
 
 import org.apache.spark.sql.types._
 
-object Schema {
+private[api] object Schema {
   val repositories = StructType(
     StructField("id", StringType) ::
       StructField("urls", ArrayType(StringType, containsNull = false)) ::

--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -2,18 +2,113 @@ package tech.sourced.api
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+/**
+  * SparkAPI is the main entry point to all usage of the source{d} spark-api.
+  * It has methods to configure all possible configurable options as well as
+  * the available methods to start analysing repositories of code.
+  *
+  * {{{
+  * import tech.sourced.api._
+  *
+  * val api = SparkAPI(sparkSession, "/path/to/repositories")
+  * }}}
+  *
+  * NOTE: Keep in mind that you will need to register the UDFs in the session
+  * manually if you choose to instantiate this class directly instead of using
+  * the companion object.
+  *
+  * {{{
+  * import tech.sourced.api.{SparkAPI, SessionFunctions}
+  *
+  * api = new SparkAPI(sparkSession)
+  * sparkSession.registerUDFs()
+  * }}}
+  *
+  * The only method available as of now is getRepositories, which will generate
+  * a DataFrame of repositories, which is the very first thing you need to
+  * analyse repositories of code.
+  *
+  * @constructor creates a SparkAPI instance with the given Spark session.
+  * @param session Spark session to be used
+  */
 class SparkAPI(session: SparkSession) {
 
+  /**
+    * Returns a DataFrame with the data about the repositories found at
+    * the specified repositories path in the form of siva files.
+    * To call this method you need to have set before the repositories path,
+    * you can do so by calling setRepositoriesPath or, preferably, instantiating
+    * the SparkAPI using the companion object.
+    *
+    * {{{
+    * val reposDf = api.getRepositories
+    * }}}
+    *
+    * @return DataFrame
+    */
   def getRepositories(): DataFrame = getDataSource("repositories", session)
 
+  /**
+    * Sets the path where the siva files of the repositories are stored.
+    * Although this can actually be called the proper way to use SparkAPI is
+    * to instantiate it using the SparkAPI companion object, which already
+    * asks for the path in its apply method. If you already instantiated the
+    * API instance using the SparkAPI companion object you don't need to call
+    * this unless you want to change the repositories path.
+    * Note that setting this will affect the session, so any other uses of the
+    * session outside the SparkAPI instance will also have that config set.
+    *
+    * {{{
+    * api.setRepositoriesPath("/path/to/repositories")
+    * }}}
+    *
+    * @param path of the siva files.
+    * @return instance of the api itself
+    */
   def setRepositoriesPath(path: String): SparkAPI = {
     session.sqlContext.setConf(repositoriesPathKey, path)
     this
   }
 
+  /**
+    * Configures the endpoint used to connect to the bblfsh GRPC server.
+    * Note that setting this will affect the session, so any other uses of the
+    * session outside the SparkAPI instance will also have that config set.
+    *
+    * {{{
+    * api.setBblfshGRPCEndpoint("my.grpc.server", 9432)
+    * }}}
+    *
+    * @param host of the GRPC server (0.0.0.0 by default)
+    * @param port of the GRPC server (9432 by default)
+    * @return instance of the api itself
+    */
+  def setBblfshGRPCEndpoint(host: String, port: Int): SparkAPI = {
+    session.sparkContext.getConf.set(bblfshHostKey, host)
+    session.sparkContext.getConf.set(bblfsPortKey, port.toString())
+    this
+  }
+
 }
 
+/**
+  * Factory for [[tech.sourced.api.SparkAPI]] instances.
+  */
 object SparkAPI {
+  /**
+    * Creates a new SparkAPI instance with the given Spark session and
+    * configures the repositories path for that session.
+    *
+    * {{{
+    * import tech.sourced.api._
+    *
+    * val api = SparkAPI(sparkSession, "/path/to/repositories")
+    * }}}
+    *
+    * @param session spark session to use
+    * @param repositoriesPath the path to the repositories' siva files
+    * @return SparkAPI instance
+    */
   def apply(session: SparkSession, repositoriesPath: String) = {
     session.registerUDFs()
     new SparkAPI(session)

--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -1,0 +1,22 @@
+package tech.sourced.api
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+class SparkAPI(session: SparkSession) {
+
+  def getRepositories(): DataFrame = getDataSource("repositories", session)
+
+  def setRepositoriesPath(path: String): SparkAPI = {
+    session.sqlContext.setConf(repositoriesPathKey, path)
+    this
+  }
+
+}
+
+object SparkAPI {
+  def apply(session: SparkSession, repositoriesPath: String) = {
+    session.registerUDFs()
+    new SparkAPI(session)
+      .setRepositoriesPath(repositoriesPath)
+  }
+}

--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -1,31 +1,16 @@
-package tech.sourced.api
+package tech.sourced
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import tech.sourced.api.customudf.{CustomUDF, ClassifyLanguagesUDF}
+import tech.sourced.api.customudf.{ClassifyLanguagesUDF, CustomUDF}
 
-object Implicits {
-
-  val repositoriesPathKey = "tech.sourced.api.repositories.path"
+package object api {
+  private[api] val repositoriesPathKey = "tech.sourced.api.repositories.path"
 
   implicit class SessionFunctions(session: SparkSession) {
     def registerUDFs(): Unit = {
       SessionFunctions.UDFtoRegister.foreach(customUDF => session.udf.register(customUDF.name, customUDF.function))
     }
-
-    def getRepositories(): DataFrame = Implicits.getDataSource("repositories", session)
-
-    def setRepositoriesPath(path: String): SparkSession = {
-      session.sqlContext.setConf(Implicits.repositoriesPathKey, path)
-      session
-    }
-  }
-
-  object SessionFunctions {
-    val UDFtoRegister = List[CustomUDF](
-      ClassifyLanguagesUDF
-    )
   }
 
   implicit class ApiDataFrame(df: DataFrame) {
@@ -33,48 +18,52 @@ object Implicits {
     import df.sparkSession.implicits._
 
     def getReferences: DataFrame = {
-      Implicits.checkCols(df, "id")
+      checkCols(df, "id")
       val reposIdsDf = df.select($"id").distinct()
-      Implicits.getDataSource("references", df.sparkSession).join(reposIdsDf, $"repository_id" === $"id").drop($"id")
+      getDataSource("references", df.sparkSession).join(reposIdsDf, $"repository_id" === $"id").drop($"id")
     }
 
     def getCommits: DataFrame = {
-      Implicits.checkCols(df, "repository_id")
+      checkCols(df, "repository_id")
       val refsIdsDf = df.select($"name", $"repository_id").distinct()
-      val commitsDf = Implicits.getDataSource("commits", df.sparkSession)
+      val commitsDf = getDataSource("commits", df.sparkSession)
       commitsDf.join(refsIdsDf, refsIdsDf("repository_id") === commitsDf("repository_id") &&
         commitsDf("reference_name") === refsIdsDf("name"))
         .drop(refsIdsDf("name")).drop(refsIdsDf("repository_id"))
     }
 
     def getFiles: DataFrame = {
-      val filesDf = Implicits.getDataSource("files", df.sparkSession)
+      val filesDf = getDataSource("files", df.sparkSession)
 
       if (df.schema.fieldNames.contains("hash")) {
         val commitsDf = df.drop("tree").distinct()
         filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
       } else {
-        Implicits.checkCols(df, "reference_name")
+        checkCols(df, "reference_name")
         filesDf
       }
     }
 
     def classifyLanguages: DataFrame = {
-      Implicits.checkCols(df, "is_binary", "path", "content")
+      checkCols(df, "is_binary", "path", "content")
       df.withColumn("lang", ClassifyLanguagesUDF.function('is_binary, 'path, 'content))
     }
   }
 
-  def getDataSource(table: String, session: SparkSession): DataFrame =
+  private[api] def getDataSource(table: String, session: SparkSession): DataFrame =
     session.read.format("tech.sourced.api.DefaultSource")
       .option("table", table)
       .load(session.sqlContext.getConf(repositoriesPathKey))
 
-  def checkCols(df: DataFrame, cols: String*): Unit = {
+  private[api] def checkCols(df: DataFrame, cols: String*): Unit = {
     if (!df.schema.fieldNames.containsSlice(cols)) {
       throw new SparkException("method cannot be applied into this DataFrame")
     }
   }
 
+  private[api] object SessionFunctions {
+    val UDFtoRegister = List[CustomUDF](
+      ClassifyLanguagesUDF
+    )
+  }
 }
-

--- a/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/api/BaseSparkSpec.scala
@@ -15,8 +15,6 @@ trait BaseSparkSpec extends BeforeAndAfterAll {
       .appName("test").master("local[*]")
       .config("spark.driver.host", "localhost")
       .getOrCreate()
-
-    import Implicits._
     ss.registerUDFs()
   }
 

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -38,12 +38,10 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
   "Additional methods" should "work correctly" in {
     val spark = ss
 
-    spark.sqlContext.setConf("tech.sourced.api.repositories.path", resourcePath)
-
     import Implicits._
     import spark.implicits._
 
-    val reposDf = spark.getRepositories
+    val reposDf = spark.setRepositoriesPath(resourcePath).getRepositories
       .filter($"id" === "github.com/mawag/faq-xiyoulinux" || $"id" === "github.com/xiyou-linuxer/faq-xiyoulinux")
     val refsDf = reposDf.getReferences.filter($"name".equalTo("refs/heads/HEAD"))
 
@@ -62,12 +60,11 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
   "Convenience for getting files" should "work without commits" in {
     val spark = ss
-    spark.sqlContext.setConf("tech.sourced.api.repositories.path", resourcePath)
 
     import Implicits._
     import spark.implicits._
 
-    val filesDf = ss
+    val filesDf = spark.setRepositoriesPath(resourcePath)
       .getRepositories.filter($"id" === "github.com/mawag/faq-xiyoulinux")
       .getReferences.filter($"name".equalTo("refs/heads/HEAD"))
       .getFiles

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -38,10 +38,9 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
   "Additional methods" should "work correctly" in {
     val spark = ss
 
-    import Implicits._
     import spark.implicits._
 
-    val reposDf = spark.setRepositoriesPath(resourcePath).getRepositories
+    val reposDf = SparkAPI(spark, resourcePath).getRepositories
       .filter($"id" === "github.com/mawag/faq-xiyoulinux" || $"id" === "github.com/xiyou-linuxer/faq-xiyoulinux")
     val refsDf = reposDf.getReferences.filter($"name".equalTo("refs/heads/HEAD"))
 
@@ -60,11 +59,9 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
   "Convenience for getting files" should "work without commits" in {
     val spark = ss
-
-    import Implicits._
     import spark.implicits._
 
-    val filesDf = spark.setRepositoriesPath(resourcePath)
+    val filesDf = SparkAPI(spark, resourcePath)
       .getRepositories.filter($"id" === "github.com/mawag/faq-xiyoulinux")
       .getReferences.filter($"name".equalTo("refs/heads/HEAD"))
       .getFiles

--- a/src/test/scala/tech/sourced/api/customudf/CustomUDFSpec.scala
+++ b/src/test/scala/tech/sourced/api/customudf/CustomUDFSpec.scala
@@ -2,7 +2,7 @@ package tech.sourced.api.customudf
 
 import org.apache.spark.sql.types.{StringType, StructField}
 import org.scalatest.{FlatSpec, Matchers}
-import tech.sourced.api.{BaseSparkSpec, Implicits}
+import tech.sourced.api._
 
 class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
 
@@ -19,8 +19,6 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
 
   "Language detection" should "works correctly" in {
     val spark = ss
-
-    import Implicits._
     import spark.implicits._
 
     val languagesDf = fileSeq.toDF(fileColumns: _*).classifyLanguages
@@ -31,7 +29,6 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
 
   it should "guess the correct language" in {
     val spark = ss
-    import Implicits._
     import spark.implicits._
 
     val languagesDf = fileSeq.toDF(fileColumns: _*).classifyLanguages


### PR DESCRIPTION
I think adding this function to the spark session simplifies a bit the experience of the user of the library.

Before

```scala
spark.sqlContext.setConf("tech.sourced.api.repositories.path", "/path/to/files")
```

Now

```scala
spark.setRepositoriesPath("/path/to/files")
```

We could even check if the path exists and contains siva files there and so on in the future.