### PR TITLE
Fix: race condition on copy

### DIFF
--- a/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
@@ -8,6 +8,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.input.PortableDataStream
+import org.apache.spark.internal.Logging
 import org.eclipse.jgit.lib.{Repository, RepositoryBuilder}
 import tech.sourced.api.util.MD5Gen
 import tech.sourced.siva.SivaReader
@@ -15,12 +16,12 @@ import tech.sourced.siva.SivaReader
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
 
-class RepositoryProvider(val localPath: String) {
+class RepositoryProvider(val localPath: String) extends Logging {
   private val repositories: concurrent.Map[String, Repository] =
     new ConcurrentHashMap[String, Repository]().asScala
 
   def get(conf: Configuration, path: String): Repository =
-    repositories.getOrElseUpdate(path, RepositoryProvider.genRepository(conf, path, localPath))
+    repositories.getOrElseUpdate(path, genRepository(conf, path, localPath))
 
   def get(pds: PortableDataStream): Repository =
     this.get(pds.getConfiguration, pds.getPath())
@@ -31,40 +32,21 @@ class RepositoryProvider(val localPath: String) {
       // TODO maybe others are using this repository instance
       // FileUtils.deleteQuietly(r.getDirectory)
     })
-}
-
-object RepositoryProvider {
-  var provider: RepositoryProvider = _
-
-  def apply(localPath: String): RepositoryProvider = {
-    if (provider == null) {
-      provider = new RepositoryProvider(localPath)
-    }
-
-    if (provider.localPath != localPath) {
-      throw new RuntimeException(s"actual provider instance is not intended " +
-        s"to be used with the localPath provided: $localPath")
-    }
-
-    provider
-  }
-
-  val temporalLocalFolder = "processing-repositories"
-  val temporalSivaFolder = "siva-files"
 
   private def genRepository(conf: Configuration, path: String, localPath: String): Repository = {
     val remotePath = new Path(path)
 
     val localCompletePath =
       new Path(localPath,
-        new Path(temporalLocalFolder,
+        new Path(RepositoryProvider.temporalLocalFolder,
           new Path(MD5Gen.str(path), remotePath.getName)
         )
       )
 
-    val localSivaPath = new Path(localPath, new Path(temporalSivaFolder, remotePath.getName))
+    val localSivaPath = new Path(localPath, new Path(RepositoryProvider.temporalSivaFolder, remotePath.getName))
 
     // Copy siva file to local fs
+    log.debug(s"Copy $remotePath to $localSivaPath")
     FileSystem.get(conf)
       .copyToLocalFile(remotePath, localSivaPath)
 
@@ -86,4 +68,25 @@ object RepositoryProvider {
 
     repo
   }
+
+}
+
+object RepositoryProvider {
+  var provider: RepositoryProvider = _
+
+  def apply(localPath: String): RepositoryProvider = {
+    if (provider == null) {
+      provider = new RepositoryProvider(localPath)
+    }
+
+    if (provider.localPath != localPath) {
+      throw new RuntimeException(s"actual provider instance is not intended " +
+        s"to be used with the localPath provided: $localPath")
+    }
+
+    provider
+  }
+
+  val temporalLocalFolder = "processing-repositories"
+  val temporalSivaFolder = "siva-files"
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -9,3 +9,4 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: 
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.tech.sourced.api.iterator.BlobIterator=INFO
+log4j.logger.tech.sourced.api.provider.RepositoryProvider=DEBUG


### PR DESCRIPTION
Changes:
 - adds synchronization around the repository copy
 - adds logging to RepositoryProvider

Motivation:
#28 with atomic `Map.getOrElseUpdate` might be not enough, as it still can run file copy multiple times.

According to the [`MapLike.html#getOrElseUpdate`](https://www.scala-lang.org/api/current/scala/collection/mutable/MapLike.html#getOrElseUpdate(key:K,op:=>V):V)  docs:
> Concurrent map implementations may evaluate the expression op multiple times, or may evaluate op without inserting the result.

