### PR TITLE
api: add filters to reference dataframes for python api parity

### DIFF
--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -113,6 +113,51 @@ package object api {
     }
 
     /**
+      * Returns a new [[org.apache.spark.sql.DataFrame]] containing only the rows
+      * with a HEAD reference.
+      *
+      * {{{
+      * val headDf = refsDf.getHEAD
+      * }}}
+      *
+      * @return new dataframe with only HEAD reference rows
+      */
+    def getHEAD: DataFrame = getReference("refs/heads/HEAD")
+
+    /**
+      * Returns a new [[org.apache.spark.sql.DataFrame]] containing only the rows
+      * with a master reference.
+      *
+      * {{{
+      * val masterDf = refsDf.getMaster
+      * }}}
+      *
+      * @return new dataframe with only the master reference rows
+      */
+    def getMaster: DataFrame = getReference("refs/heads/master")
+
+    /**
+      * Returns a new [[org.apache.spark.sql.DataFrame]] containing only the rows
+      * with a reference whose name equals the one provided.
+      *
+      * {{{
+      * val developDf = refsDf.getReference("refs/heads/develop")
+      * }}}
+      *
+      * @param name name of the reference to filter by
+      * @return new dataframe with only the given reference rows
+      */
+    def getReference(name: String): DataFrame = {
+      if (df.schema.fieldNames.contains("reference_name")) {
+        df.filter($"reference_name" === name)
+      } else if (df.schema.fieldNames.contains("name")) {
+        df.filter($"name" === name)
+      } else {
+        df.getReferences.getReference(name)
+      }
+    }
+
+    /**
       * Returns a new [[org.apache.spark.sql.DataFrame]] with a new column "lang" added
       * containing the language of the file.
       * It requires the current dataframe to have the files data.

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -42,7 +42,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     val reposDf = SparkAPI(spark, resourcePath).getRepositories
       .filter($"id" === "github.com/mawag/faq-xiyoulinux" || $"id" === "github.com/xiyou-linuxer/faq-xiyoulinux")
-    val refsDf = reposDf.getReferences.filter($"name".equalTo("refs/heads/HEAD"))
+    val refsDf = reposDf.getReferences.getHEAD
 
     val commitsDf = refsDf.getCommits.select("repository_id", "reference_name", "message", "hash")
     commitsDf.show()
@@ -63,7 +63,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     val filesDf = SparkAPI(spark, resourcePath)
       .getRepositories.filter($"id" === "github.com/mawag/faq-xiyoulinux")
-      .getReferences.filter($"name".equalTo("refs/heads/HEAD"))
+      .getReferences.getHEAD
       .getFiles
       .select("repository_id", "name", "path", "commit_hash", "file_hash", "content")
 
@@ -72,6 +72,58 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     assert(cnt != 0)
 
     filesDf.show()
+  }
+
+  "Filter by reference from repos dataframe" should "work" in {
+    val spark = ss
+
+    val count = SparkAPI(spark, resourcePath)
+      .getRepositories
+      .getReference("refs/heads/develop")
+      .count()
+
+    assert(count == 2)
+  }
+
+  "Filter by reference from commits dataframe" should "work" in {
+    val spark = ss
+
+    val count = SparkAPI(spark, resourcePath)
+      .getRepositories
+        .getReferences
+        .getCommits
+      .getReference("refs/heads/develop")
+      .count()
+
+    assert(count == 103)
+  }
+
+  "Filter by reference from references dataframe" should "work" in {
+    val spark = ss
+
+    val count = SparkAPI(spark, resourcePath)
+      .getRepositories
+      .getReferences
+      .getReference("refs/heads/develop")
+      .count()
+
+    assert(count == 2)
+  }
+
+  "Filter by HEAD reference" should "return only HEAD references" in {
+    val spark = ss
+    val count = SparkAPI(spark, resourcePath).getRepositories.getHEAD
+      .select("name").distinct().count()
+
+    assert(count == 1)
+  }
+
+  "Filter by master reference" should "return only master references" in {
+    val spark = ss
+    val count = SparkAPI(spark, resourcePath).getRepositories.getMaster
+      .select("name").distinct().count()
+
+    assert(count == 1)
   }
 
 }


### PR DESCRIPTION
Adds `getReference`,  `getHEAD` and `getMaster` for parity with python API.