### PR TITLE
HOTFIX: fix building a fatJar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_script:
   - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION jacoco:cover
+  - ./sbt ++$TRAVIS_SCALA_VERSION jacoco:cover
+  - ./sbt assembly
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -35,3 +35,11 @@ jacoco.reportFormats in jacoco.Config := Seq(
 
 parallelExecution in Test := false
 logBuffered in Test := false
+
+
+assemblyMergeStrategy in assembly := {
+  case "META-INF/io.netty.versions.properties" => MergeStrategy.last
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}


### PR DESCRIPTION
#41 introduced a netty version, fixed for gRPC and `./sbt assembly` require some guidance in such cases.

This PR fixes that and adds `./sbt assembly` to CI to avoid such things in the future