### PR TITLE
iterator: implement CleanupIterator to clean unpacked resources

### DIFF
--- a/src/main/scala/tech/sourced/api/iterator/CleanupIterator.scala
+++ b/src/main/scala/tech/sourced/api/iterator/CleanupIterator.scala
@@ -1,0 +1,25 @@
+package tech.sourced.api.iterator
+
+import org.apache.spark.{InterruptibleIterator, TaskContext}
+import org.apache.spark.sql.Row
+
+class CleanupIterator[T](it: RootedRepoIterator[T], cleanup: => Unit)
+  extends InterruptibleIterator[Row](TaskContext.get(), it) {
+
+  override def hasNext: Boolean = {
+    try {
+      val hasNext = super.hasNext
+      if (!hasNext) {
+        val _ = cleanup
+      }
+      hasNext
+    } catch {
+      case e: Throwable => {
+        val _ = cleanup
+        throw e
+      }
+    }
+  }
+
+  override def next(): Row = super.next()
+}

--- a/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/api/provider/RepositoryProvider.scala
@@ -80,7 +80,7 @@ class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false
     val localSivaPath = new Path(localPath, new Path(RepositoryProvider.temporalSivaFolder, remotePath.getName))
     val fs = FileSystem.get(conf)
 
-    if (!fs.exists(localSivaPath)) {
+    if (!fs.exists(localSivaPath) && !fs.exists(localCompletePath)) {
       // Copy siva file to local fs
       log.debug(s"Copy $remotePath to $localSivaPath")
       fs.copyToLocalFile(remotePath, localSivaPath)
@@ -88,6 +88,7 @@ class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false
 
     if (!fs.exists(localCompletePath)) {
       // unpack siva file
+      log.debug(s"Unpack siva file $localSivaPath to $localCompletePath")
       val sr = new SivaReader(new File(localSivaPath.toString))
       val index = sr.getIndex.getFilteredIndex.getEntries.asScala
       index.foreach(ie => {

--- a/src/test/scala/tech/sourced/api/provider/RepositoryProviderSpec.scala
+++ b/src/test/scala/tech/sourced/api/provider/RepositoryProviderSpec.scala
@@ -1,9 +1,8 @@
 package tech.sourced.api.provider
 
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.input.PortableDataStream
 import org.eclipse.jgit.lib.ObjectId
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 import tech.sourced.api.{BaseSivaSpec, BaseSparkSpec}
 
 import scala.collection.JavaConverters._
@@ -79,6 +78,46 @@ class RepositoryProviderSpec extends FlatSpec with Matchers with BaseSivaSpec wi
 
     assert(sivaFilesExist.length == 3)
     assert(sivaFilesExist.forall(!_))
+  }
+
+  "RepositoryProvider" should "cleanup unpacked files when nobody else is using the repo" in {
+    val prov = SivaRDDProvider(ss.sparkContext)
+    val sivaRDD = prov.get(resourcePath)
+    val pds = sivaRDD.first()
+
+    // needs to be a fresh instance, since some of the tests may not cleanup
+    val provider = new RepositoryProvider("/tmp/cleanup-test-" + System.currentTimeMillis())
+
+    val repo = provider.get(pds)
+    val fs = FileSystem.get(pds.getConfiguration)
+    provider.get(pds)
+
+    provider.close(pds.getPath())
+    repo.getDirectory().toPath()
+    fs.exists(new Path(repo.getDirectory().toString())) should be(true)
+
+    provider.close(pds.getPath())
+    fs.exists(new Path(repo.getDirectory().toString())) should be(false)
+  }
+
+  "RepositoryProvider with skipCleanup = true" should "not cleanup unpacked files when nobody else is using the repo" in {
+    val prov = SivaRDDProvider(ss.sparkContext)
+    val sivaRDD = prov.get(resourcePath)
+    val pds = sivaRDD.first()
+
+    // needs to be a fresh instance, since some of the tests may not cleanup
+    val provider = new RepositoryProvider("/tmp/cleanup-test-" + System.currentTimeMillis(), skipCleanup = true)
+
+    val repo = provider.get(pds)
+    val fs = FileSystem.get(pds.getConfiguration)
+    provider.get(pds)
+
+    provider.close(pds.getPath())
+    repo.getDirectory().toPath()
+    fs.exists(new Path(repo.getDirectory().toString())) should be(true)
+
+    provider.close(pds.getPath())
+    fs.exists(new Path(repo.getDirectory().toString())) should be(true)
   }
 
 }


### PR DESCRIPTION
Fixes #29 

### Design decisions

I implemented a `CleanupIterator`, which is basically an iterator extending `InterruptibleIterator` that executes some cleanup code when there is an exception (`Throwable` because `TaskKilledException` is not public :disappointed: )

Whenever a repository is fully iterated and done with (or something was thrown from inside), it's closed and its unpacked files deleted if there is nobody else using it. Otherwise, just keeps them open until the last one using them closes the repo.

I don't personally fancy much the refcount approach for this, but you still need it if you add a listener on the task context, because multiple tasks can be using the same repo. The iterator approach I felt it was cleaner than the task context one and `CompletionIterator` is private. Anyway, `CleanupIterator` is basically a `CompletionIterator` that cleans up when there is an exception as well.Fixes #29 
