### PR TITLE
api: throw error if the repositories path does not exist

### DIFF
--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -1,5 +1,7 @@
 package tech.sourced.api
 
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -66,6 +68,10 @@ class SparkAPI(session: SparkSession) {
     * @return instance of the api itself
     */
   def setRepositoriesPath(path: String): SparkAPI = {
+    if (!FileSystem.get(session.sparkContext.hadoopConfiguration).exists(new Path(path))) {
+      throw new SparkException(s"the given repositories path ($path) does not exist, so siva files can't be read from there")
+    }
+
     session.sqlContext.setConf(repositoriesPathKey, path)
     this
   }


### PR DESCRIPTION
Fixes #52 

Now it crashes with something like

```
py4j.protocol.Py4JJavaError: An error occurred while calling z:tech.sourced.api.SparkAPI.apply.
: org.apache.spark.SparkException: the given repositories path (/path/to/siva/files) does not exist, so siva files can't be read from there
	at tech.sourced.api.SparkAPI.setRepositoriesPath(SparkAPI.scala:72)
	at tech.sourced.api.SparkAPI$.apply(SparkAPI.scala:141)
	at tech.sourced.api.SparkAPI.apply(SparkAPI.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:280)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:214)
	at java.lang.Thread.run(Thread.java:748)
```