### PR TITLE
[DOC] added basic examples to works with docsrv

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,15 @@
+# spark-api
+
+Here you can find a list of annotated *spark-api* examples:
+
+### pyspark
+
+-  [pyspark's shell  basic example](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-basic.md)
+
+### scala
+
+- [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
+
+### jupyter notebooks
+
+- [Basic example](https://github.com/src-d/spark-api/blob/master/_examples/notebooks/Basic%2BExample.ipynb)

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -12,6 +12,8 @@ Here you can find a list of annotated *spark-api* examples:
 
 - [pyspark's shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-schemas.md)
 
+- [pyspark's shell classifying languages and extracting UASTs](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-lang-and-uast.md)
+
 ### scala
 
 - [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
@@ -21,6 +23,8 @@ Here you can find a list of annotated *spark-api* examples:
 - [spark-shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-classifying-languages.md)
 
 - [spark-shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-schemas.md)
+
+- [spark-shell classifying languages and extracting UASTs](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-lang-and-uast.md)
 
 ### jupyter notebooks
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -4,15 +4,19 @@ Here you can find a list of annotated *spark-api* examples:
 
 ### pyspark
 
--  [pyspark's shell  basic example](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-basic.md)
+- [pyspark's shell  basic example](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-basic.md)
 
 - [pyspark's shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-uast-extraction.md)
+
+- [pyspark's shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-classifying-languages.md)
 
 ### scala
 
 - [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
 
 - [spark-shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-uast-extraction.md)
+
+- [spark-shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-classifying-languages.md)
 
 ### jupyter notebooks
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -6,9 +6,13 @@ Here you can find a list of annotated *spark-api* examples:
 
 -  [pyspark's shell  basic example](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-basic.md)
 
+- [pyspark's shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-uast-extraction.md)
+
 ### scala
 
 - [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
+
+- [spark-shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-uast-extraction.md)
 
 ### jupyter notebooks
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -10,6 +10,8 @@ Here you can find a list of annotated *spark-api* examples:
 
 - [pyspark's shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-classifying-languages.md)
 
+- [pyspark's shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-schemas.md)
+
 ### scala
 
 - [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
@@ -17,6 +19,8 @@ Here you can find a list of annotated *spark-api* examples:
 - [spark-shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-uast-extraction.md)
 
 - [spark-shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-classifying-languages.md)
+
+- [spark-shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-schemas.md)
 
 ### jupyter notebooks
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -4,28 +4,28 @@ Here you can find a list of annotated *spark-api* examples:
 
 ### pyspark
 
-- [pyspark's shell  basic example](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-basic.md)
+- [pyspark's shell  basic example](pyspark/pyspark-shell-basic.md)
 
-- [pyspark's shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-uast-extraction.md)
+- [pyspark's shell UAST extraction](pyspark/pyspark-shell-uast-extraction.md)
 
-- [pyspark's shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-classifying-languages.md)
+- [pyspark's shell classifying languages](pyspark/pyspark-shell-classifying-languages.md)
 
-- [pyspark's shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-schemas.md)
+- [pyspark's shell data schemas](pyspark/pyspark-shell-schemas.md)
 
-- [pyspark's shell classifying languages and extracting UASTs](https://github.com/src-d/spark-api/blob/master/_examples/pyspark/pyspark-shell-lang-and-uast.md)
+- [pyspark's shell classifying languages and extracting UASTs](pyspark/pyspark-shell-lang-and-uast.md)
 
 ### scala
 
-- [spark-shell basic example](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-basic.md)
+- [spark-shell basic example](scala/spark-shell-basic.md)
 
-- [spark-shell UAST extraction](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-uast-extraction.md)
+- [spark-shell UAST extraction](scala/spark-shell-uast-extraction.md)
 
-- [spark-shell classifying languages](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-classifying-languages.md)
+- [spark-shell classifying languages](scala/spark-shell-classifying-languages.md)
 
-- [spark-shell data schemas](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-schemas.md)
+- [spark-shell data schemas](scala/spark-shell-schemas.md)
 
-- [spark-shell classifying languages and extracting UASTs](https://github.com/src-d/spark-api/blob/master/_examples/scala/spark-shell-lang-and-uast.md)
+- [spark-shell classifying languages and extracting UASTs](scala/spark-shell-lang-and-uast.md)
 
 ### jupyter notebooks
 
-- [Basic example](https://github.com/src-d/spark-api/blob/master/_examples/notebooks/Basic%2BExample.ipynb)
+- [Basic example](notebooks/Basic%2BExample.ipynb)

--- a/_examples/notebooks/Basic+Example.ipynb
+++ b/_examples/notebooks/Basic+Example.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from sourced.spark import API as SparkAPI\n",
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder\\\n",
+    ".master(\"local\").appName(\"Examples\")\\\n",
+    ".getOrCreate()\n",
+    "\n",
+    "api = SparkAPI(spark, \"/repositories\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "repositories_df = api.repositories\n",
+    "references_df = repositories_df.references\n",
+    "commits_df = references_df.commits\n",
+    "files_df = commits_df.files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get all HEAD references for all the repositories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "heads_df = references_df.head_ref"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get repositories that are marked as no forks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "no_forks_df = repositories_df.filter(repositories_df.is_fork == 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get only references for original repositories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "no_forks_heads_df = heads_df.join(no_forks_df, heads_df.repository_id == no_forks_df.id).drop('repository_id').distinct()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "head_commits_df = no_forks_heads_df.join(commits_df, no_forks_heads_df.hash == commits_df.hash)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------------+--------------------+--------------------+--------------------+-------+\n",
+      "|           name|                hash|                  id|                urls|is_fork|\n",
+      "+---------------+--------------------+--------------------+--------------------+-------+\n",
+      "|refs/heads/HEAD|fff7062de8474d10a...|github.com/xiyou-...|[git://github.com...|  false|\n",
+      "|refs/heads/HEAD|dbfab055c70379219...|github.com/waynee...|[git://github.com...|  false|\n",
+      "|refs/heads/HEAD|202ceb4d3efd22945...|anongit.kde.org/s...|[https://anongit....|  false|\n",
+      "|refs/heads/HEAD|2060ee6252a64337c...|anongit.kde.org/p...|[https://anongit....|  false|\n",
+      "+---------------+--------------------+--------------------+--------------------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "no_forks_heads_df.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "head_commits_df.drop(\"blobs\").drop(\"files\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "files_df.limit(20).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/_examples/pyspark/pyspark-shell-basic.md
+++ b/_examples/pyspark/pyspark-shell-basic.md
@@ -1,3 +1,11 @@
+## Basic example
+
+In this example, the pyspark-shell is used to show a simple usage of the spark-api.
+
+First, you can see how to import the package and instantiate and object that provide all the methods to manipulate the data retrieved from repositories.
+
+The `api` object is used to get all the repositories, get the `HEAD` references from the repositories and eventually, get all the files from these references. Then a table is showed selecting the columns `file_hash`, `path` and reference `name`.
+
 ```bash
 $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 >>> from sourced.spark import API as SparkAPI

--- a/_examples/pyspark/pyspark-shell-basic.md
+++ b/_examples/pyspark/pyspark-shell-basic.md
@@ -1,0 +1,32 @@
+```bash
+$ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+>>> from sourced.spark import API as SparkAPI
+>>> api = SparkAPI(spark, '/path/to/siva-files')
+>>> api.repositories.references.head_ref.files.select('file_hash', 'path', 'name').show()
++--------------------+--------------------+---------------+
+|           file_hash|                path|           name|
++--------------------+--------------------+---------------+
+|bdbf905450bc30b51...|            Rakefile|refs/heads/HEAD|
+|fee334944ecfdb0a2...|model_plugins/Rak...|refs/heads/HEAD|
+|e69de29bb2d1d6434...|model_plugins/acc...|refs/heads/HEAD|
+|1147a1711b11a32d7...|model_plugins/acc...|refs/heads/HEAD|
+|e69de29bb2d1d6434...|model_plugins/acc...|refs/heads/HEAD|
+|fcb93890e049dac4a...|model_plugins/acc...|refs/heads/HEAD|
+|f7157b33e0bf58f65...|model_plugins/acc...|refs/heads/HEAD|
+|ec1782aa450914a33...|model_plugins/acc...|refs/heads/HEAD|
+|42900ddf5dfccf25c...|model_plugins/acc...|refs/heads/HEAD|
+|d452a6eb34ce195c8...|model_plugins/acc...|refs/heads/HEAD|
+|e69de29bb2d1d6434...|model_plugins/aut...|refs/heads/HEAD|
+|1147a1711b11a32d7...|model_plugins/aut...|refs/heads/HEAD|
+|8eb073459693cba66...|model_plugins/aut...|refs/heads/HEAD|
+|291e140054f63737a...|model_plugins/aut...|refs/heads/HEAD|
+|db32a46ea544164a4...|model_plugins/aut...|refs/heads/HEAD|
+|107f0ec8025e626d6...|model_plugins/aut...|refs/heads/HEAD|
+|42900ddf5dfccf25c...|model_plugins/aut...|refs/heads/HEAD|
+|2dc8d738c6ae57567...|model_plugins/aut...|refs/heads/HEAD|
+|e69de29bb2d1d6434...|model_plugins/deq...|refs/heads/HEAD|
+|1147a1711b11a32d7...|model_plugins/deq...|refs/heads/HEAD|
++--------------------+--------------------+---------------+
+only showing top 20 rows
+
+```

--- a/_examples/pyspark/pyspark-shell-classifying-languages.md
+++ b/_examples/pyspark/pyspark-shell-classifying-languages.md
@@ -1,0 +1,32 @@
+```bash
+$ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+>>> from sourced.spark import API as SparkAPI
+>>> api = SparkAPI(spark, '/path/to/siva-files')
+>>> api.repositories.references.head_ref.files.classify_languages().select("file_hash", "path", "lang").show()
++--------------------+--------------------+--------+
+|           file_hash|                path|    lang|
++--------------------+--------------------+--------+
+|73fe61e5132f518f7...|          .gitignore|    null|
+|bf17d9730e43f5697...|         .travis.yml|    YAML|
+|524518a5bc6517f35...|             LICENSE|    Text|
+|8a9ea646b7936344d...|           README.md|Markdown|
+|e35a52f431feac4b7...|          abs/abs.py|  Python|
+|4d3617f27e277e4b5...|differentiation/s...|  Python|
+|e543efaa2472ca990...|euclidean/distanc...|  Python|
+|8ab978a56c5dcb239...|factorial/factori...|  Python|
+|bc9f129c7240b473c...|factorial/factori...|  Python|
+|ff4fa0794274a7ffb...|fibonacci/fibonac...|  Python|
+|26f33ebf9fc10ade0...|fibonacci/fibonac...|  Python|
+|34ec07bb8fd51505f...|fibonacci/fibonac...|  Python|
+|6d7c6cb29abb52fc2...|          gcd/gcd.py|  Python|
+|969cca02388dd9339...|gcd/gcd_optimal_e...|  Python|
+|efbab3fd5b65a8808...|          lcm/lcm.py|  Python|
+|f6e3b5434694dec73...|lcm/lcm_optimal_e...|  Python|
+|ff24547f19fb5afc2...|   prime/is_prime.py|  Python|
+|0b21309064736ec48...|prime/is_prime_im...|  Python|
+|70e8349ebddde4fb8...|prime/is_prime_op...|  Python|
+|c966f781ae72efe1b...| prime/next_prime.py|  Python|
++--------------------+--------------------+--------+
+only showing top 20 rows
+
+```

--- a/_examples/pyspark/pyspark-shell-classifying-languages.md
+++ b/_examples/pyspark/pyspark-shell-classifying-languages.md
@@ -1,3 +1,9 @@
+## Classifying languages example
+
+This example uses the pyspark-shell to show how to classify files by their language with `classify_languages()`.
+
+Making use of the `api` object, it retrieves repositories to get all files from the `HEAD` references from them. After that, a call to `classify_languages()` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
+
 ```bash
 $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 >>> from sourced.spark import API as SparkAPI

--- a/_examples/pyspark/pyspark-shell-lang-and-uast.md
+++ b/_examples/pyspark/pyspark-shell-lang-and-uast.md
@@ -1,0 +1,33 @@
+```bash
+$ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+>>> from sourced.spark import API as SparkAPI
+>>> api = SparkAPI(spark, '/path/to/siva-files')
+>>> api.repositories.references.head_ref.files.classify_languages().extract_uasts().select("path", "lang", "uast").show()
+
++--------------------+--------+--------------------+
+|                path|    lang|                uast|
++--------------------+--------+--------------------+
+|          .gitignore|    null|                  []|
+|         .travis.yml|    YAML|                  []|
+|             LICENSE|    Text|                  []|
+|           README.md|Markdown|                  []|
+|          abs/abs.py|  Python|[0A 06 4D 6F 64 7...|
+|differentiation/s...|  Python|[0A 06 4D 6F 64 7...|
+|euclidean/distanc...|  Python|[0A 06 4D 6F 64 7...|
+|factorial/factori...|  Python|[0A 06 4D 6F 64 7...|
+|factorial/factori...|  Python|[0A 06 4D 6F 64 7...|
+|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|          gcd/gcd.py|  Python|[0A 06 4D 6F 64 7...|
+|gcd/gcd_optimal_e...|  Python|[0A 06 4D 6F 64 7...|
+|          lcm/lcm.py|  Python|[0A 06 4D 6F 64 7...|
+|lcm/lcm_optimal_e...|  Python|[0A 06 4D 6F 64 7...|
+|   prime/is_prime.py|  Python|[0A 06 4D 6F 64 7...|
+|prime/is_prime_im...|  Python|[0A 06 4D 6F 64 7...|
+|prime/is_prime_op...|  Python|[0A 06 4D 6F 64 7...|
+| prime/next_prime.py|  Python|[0A 06 4D 6F 64 7...|
++--------------------+--------+--------------------+
+only showing top 20 rows
+
+```

--- a/_examples/pyspark/pyspark-shell-lang-and-uast.md
+++ b/_examples/pyspark/pyspark-shell-lang-and-uast.md
@@ -1,3 +1,9 @@
+## Classifying languages and extracting UASTs example
+
+The combined usage of both, `classify_languages()` and `extract_uasts()` methods, has the advantage that doesn't rely the language detection task on the [bblfsh server](https://github.com/bblfsh/server) , so you can save some time.
+
+To do that, you just have to call  `extract_uasts()` on a Dataframe where previously, `classify_languages()` was used.
+
 ```bash
 $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 >>> from sourced.spark import API as SparkAPI

--- a/_examples/pyspark/pyspark-shell-schemas.md
+++ b/_examples/pyspark/pyspark-shell-schemas.md
@@ -1,3 +1,9 @@
+## Printing schema example
+
+The next example showed,  just try to show the simple usage of the useful method `printSchema()`.
+
+It can help you to follow the aggregated or pruned information that your transformations make on the data you are handling.
+
 ```bash
 $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 >>> from sourced.spark import API as SparkAPI

--- a/_examples/pyspark/pyspark-shell-schemas.md
+++ b/_examples/pyspark/pyspark-shell-schemas.md
@@ -1,0 +1,51 @@
+```bash
+$ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+>>> from sourced.spark import API as SparkAPI
+>>> api = SparkAPI(spark, '/path/to/siva-files')
+
+>>> api.repositories.printSchema()
+root
+ |-- id: string (nullable = true)
+ |-- urls: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- is_fork: boolean (nullable = true)
+
+>>> api.repositories.references.printSchema()
+root
+ |-- repository_id: string (nullable = true)
+ |-- name: string (nullable = true)
+ |-- hash: string (nullable = true)
+
+>>> api.repositories.references.files.printSchema()
+root
+ |-- file_hash: string (nullable = true)
+ |-- content: binary (nullable = true)
+ |-- commit_hash: string (nullable = true)
+ |-- is_binary: boolean (nullable = false)
+ |-- path: string (nullable = true)
+ |-- repository_id: string (nullable = true)
+ |-- name: string (nullable = true)
+
+>>> api.repositories.references.commits.printSchema()
+root
+ |-- repository_id: string (nullable = true)
+ |-- reference_name: string (nullable = true)
+ |-- index: integer (nullable = true)
+ |-- hash: string (nullable = true)
+ |-- message: string (nullable = true)
+ |-- parents: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- tree: map (nullable = true)
+ |    |-- key: string
+ |    |-- value: string (valueContainsNull = false)
+ |-- blobs: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- parents_count: integer (nullable = true)
+ |-- author_email: string (nullable = true)
+ |-- author_name: string (nullable = true)
+ |-- author_date: timestamp (nullable = true)
+ |-- committer_email: string (nullable = true)
+ |-- committer_name: string (nullable = true)
+ |-- committer_date: timestamp (nullable = true)
+
+```

--- a/_examples/pyspark/pyspark-shell-uast-extraction.md
+++ b/_examples/pyspark/pyspark-shell-uast-extraction.md
@@ -1,0 +1,35 @@
+```bash
+$ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+>>> from sourced.spark import API as SparkAPI
+>>> api = SparkAPI(spark, '/path/to/siva-files')
+>>> api.repositories.references.head_ref.files.extract_uasts().select("name", "path", "uast").show()
+
++---------------+--------------------+--------------------+
+|           name|                path|                uast|
++---------------+--------------------+--------------------+
+|refs/heads/HEAD|          .gitignore|                  []|
+|refs/heads/HEAD|         .travis.yml|                  []|
+|refs/heads/HEAD|             LICENSE|                  []|
+|refs/heads/HEAD|           README.md|                  []|
+|refs/heads/HEAD|          abs/abs.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|differentiation/s...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|euclidean/distanc...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|factorial/factori...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|factorial/factori...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|          gcd/gcd.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|gcd/gcd_optimal_e...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|          lcm/lcm.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|lcm/lcm_optimal_e...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|   prime/is_prime.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|prime/is_prime_im...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|prime/is_prime_op...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD| prime/next_prime.py|[0A 06 4D 6F 64 7...|
++---------------+--------------------+--------------------+
+only showing top 20 rows
+
+
+
+```

--- a/_examples/pyspark/pyspark-shell-uast-extraction.md
+++ b/_examples/pyspark/pyspark-shell-uast-extraction.md
@@ -1,3 +1,11 @@
+## Extracting UASTs example
+
+In the example code below, you can take a look to how the `extract_uasts()` method works.
+
+From the `api` object instantiated in the spark-shell, a bunch of files are retrieving from the `HEAD` references from all the repositories and requesting for them. Once we have that files, we can call `extract_uasts()` which send the files to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
+
+Finally, the reference `name`, file `path` and `uast` is showed on the table.
+
 ```bash
 $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 >>> from sourced.spark import API as SparkAPI

--- a/_examples/pyspark/pyspark-shell-uast-extraction.md
+++ b/_examples/pyspark/pyspark-shell-uast-extraction.md
@@ -30,6 +30,4 @@ $ pyspark --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories h
 +---------------+--------------------+--------------------+
 only showing top 20 rows
 
-
-
 ```

--- a/_examples/scala/spark-shell-basic.md
+++ b/_examples/scala/spark-shell-basic.md
@@ -1,0 +1,20 @@
+```bash
+$ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+scala> import tech.sourced.api._
+import tech.sourced.api._
+
+scala> val api = SparkAPI(spark, "/path/to/siva-files")
+
+scala> api.getRepositories.filter('id === "github.com/mawag/faq-xiyoulinux").
+     | getReferences.filter('name === "refs/heads/HEAD").
+     | getCommits.filter('message.contains("Initial")).
+     | select('repository_id, 'hash, 'message).
+     | show
+
+     +--------------------------------+-------------------------------+--------------------+
+     |                 repository_id|                                hash|          message|
+     +--------------------------------+-------------------------------+--------------------+
+     |github.com/mawag/...|fff7062de8474d10a...|Initial commit|
+     +--------------------------------+-------------------------------+--------------------+
+
+```

--- a/_examples/scala/spark-shell-basic.md
+++ b/_examples/scala/spark-shell-basic.md
@@ -1,3 +1,11 @@
+## Basic example
+
+In this example, the spark-shell is used to show a simple usage of the spark-api.
+
+First, you can see how to import the package and instantiate and object that provide all the methods to manipulate the data retrieved from repositories.
+
+The `api` object is used to filter repositories by `id`, get the `HEAD` references from the repositories and look for the commits in that references which contain the word `Initial` in their messages. Then a table is showed selecting the columns `repository_id`, `hash` and `message`.
+
 ```bash
 $ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 scala> import tech.sourced.api._

--- a/_examples/scala/spark-shell-classifying-languages.md
+++ b/_examples/scala/spark-shell-classifying-languages.md
@@ -1,0 +1,35 @@
+```bash
+$ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+scala> import tech.sourced.api._
+import tech.sourced.api._
+
+scala> val api = SparkAPI(spark, "/path/to/siva-files")
+
+scala> api.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getFiles.classifyLanguages.select('repository_id, 'file_hash, 'path, 'lang).show
++--------------------+--------------------+--------------------+--------+
+|       repository_id|           file_hash|                path|    lang|
++--------------------+--------------------+--------------------+--------+
+|github.com/mingra...|73fe61e5132f518f7...|          .gitignore|    null|
+|github.com/mingra...|bf17d9730e43f5697...|         .travis.yml|    YAML|
+|github.com/mingra...|524518a5bc6517f35...|             LICENSE|    Text|
+|github.com/mingra...|8a9ea646b7936344d...|           README.md|Markdown|
+|github.com/mingra...|e35a52f431feac4b7...|          abs/abs.py|  Python|
+|github.com/mingra...|4d3617f27e277e4b5...|differentiation/s...|  Python|
+|github.com/mingra...|e543efaa2472ca990...|euclidean/distanc...|  Python|
+|github.com/mingra...|8ab978a56c5dcb239...|factorial/factori...|  Python|
+|github.com/mingra...|bc9f129c7240b473c...|factorial/factori...|  Python|
+|github.com/mingra...|ff4fa0794274a7ffb...|fibonacci/fibonac...|  Python|
+|github.com/mingra...|26f33ebf9fc10ade0...|fibonacci/fibonac...|  Python|
+|github.com/mingra...|34ec07bb8fd51505f...|fibonacci/fibonac...|  Python|
+|github.com/mingra...|6d7c6cb29abb52fc2...|          gcd/gcd.py|  Python|
+|github.com/mingra...|969cca02388dd9339...|gcd/gcd_optimal_e...|  Python|
+|github.com/mingra...|efbab3fd5b65a8808...|          lcm/lcm.py|  Python|
+|github.com/mingra...|f6e3b5434694dec73...|lcm/lcm_optimal_e...|  Python|
+|github.com/mingra...|ff24547f19fb5afc2...|   prime/is_prime.py|  Python|
+|github.com/mingra...|0b21309064736ec48...|prime/is_prime_im...|  Python|
+|github.com/mingra...|70e8349ebddde4fb8...|prime/is_prime_op...|  Python|
+|github.com/mingra...|c966f781ae72efe1b...| prime/next_prime.py|  Python|
++--------------------+--------------------+--------------------+--------+
+only showing top 20 rows
+
+```

--- a/_examples/scala/spark-shell-classifying-languages.md
+++ b/_examples/scala/spark-shell-classifying-languages.md
@@ -1,3 +1,9 @@
+## Classifying languages example
+
+This example uses the spark-shell to show how to classify files by their language with `classifyLanguages`.
+
+Making use of the `api` object, it filters repositories by `id` to get all files from the `HEAD` references from them. After that, a call to `classifyLanguages` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `repository_id`, `file_hash` and `path`.
+
 ```bash
 $ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 scala> import tech.sourced.api._

--- a/_examples/scala/spark-shell-lang-and-uast.md
+++ b/_examples/scala/spark-shell-lang-and-uast.md
@@ -1,3 +1,9 @@
+## Classifying languages and extracting UASTs example
+
+The combined usage of both, `classifyLanguages` and `extractUASTs` methods, has the advantage that doesn't rely the language detection task on the [bblfsh server](https://github.com/bblfsh/server) , so you can save some time.
+
+To do that, you just have to call  `extractUASTs` on a Dataframe where previously, `classifyLanguages` was used.
+
 ```bash
 $ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 scala> import tech.sourced.api._

--- a/_examples/scala/spark-shell-lang-and-uast.md
+++ b/_examples/scala/spark-shell-lang-and-uast.md
@@ -1,0 +1,36 @@
+```bash
+$ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+scala> import tech.sourced.api._
+import tech.sourced.api._
+
+scala> val api = SparkAPI(spark, "/path/to/siva-files")
+
+scala> api.getRepositories.getHEAD.getFiles.classifyLanguages.extractUASTs.select('repository_id, 'path, 'lang, 'uast).show
+
++--------------------+--------------------+--------+--------------------+
+|       repository_id|                path|    lang|                uast|
++--------------------+--------------------+--------+--------------------+
+|github.com/mingra...|          .gitignore|    null|                  []|
+|github.com/mingra...|         .travis.yml|    YAML|                  []|
+|github.com/mingra...|             LICENSE|    Text|                  []|
+|github.com/mingra...|           README.md|Markdown|                  []|
+|github.com/mingra...|          abs/abs.py|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|differentiation/s...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|euclidean/distanc...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|factorial/factori...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|factorial/factori...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|fibonacci/fibonac...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|          gcd/gcd.py|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|gcd/gcd_optimal_e...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|          lcm/lcm.py|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|lcm/lcm_optimal_e...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|   prime/is_prime.py|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|prime/is_prime_im...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...|prime/is_prime_op...|  Python|[0A 06 4D 6F 64 7...|
+|github.com/mingra...| prime/next_prime.py|  Python|[0A 06 4D 6F 64 7...|
++--------------------+--------------------+--------+--------------------+
+only showing top 20 rows
+
+```

--- a/_examples/scala/spark-shell-schemas.md
+++ b/_examples/scala/spark-shell-schemas.md
@@ -1,0 +1,59 @@
+```bash
+$ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+scala> import tech.sourced.api._
+import tech.sourced.api._
+
+scala> val api = SparkAPI(spark, "/path/to/siva-files")
+
+scala> api.getRepositories.printSchema
+root
+ |-- id: string (nullable = true)
+ |-- urls: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- is_fork: boolean (nullable = true)
+
+
+scala> api.getRepositories.getReferenceprintSchema
+getReference   getReferences
+
+scala> api.getRepositories.getReferences.printSchema
+root
+ |-- repository_id: string (nullable = true)
+ |-- name: string (nullable = true)
+ |-- hash: string (nullable = true)
+
+
+scala> api.getRepositories.getReferences.getCommits.printSchema
+root
+ |-- repository_id: string (nullable = true)
+ |-- reference_name: string (nullable = true)
+ |-- index: integer (nullable = true)
+ |-- hash: string (nullable = true)
+ |-- message: string (nullable = true)
+ |-- parents: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- tree: map (nullable = true)
+ |    |-- key: string
+ |    |-- value: string (valueContainsNull = false)
+ |-- blobs: array (nullable = true)
+ |    |-- element: string (containsNull = false)
+ |-- parents_count: integer (nullable = true)
+ |-- author_email: string (nullable = true)
+ |-- author_name: string (nullable = true)
+ |-- author_date: timestamp (nullable = true)
+ |-- committer_email: string (nullable = true)
+ |-- committer_name: string (nullable = true)
+ |-- committer_date: timestamp (nullable = true)
+
+
+scala> api.getRepositories.getReferences.getFiles.printSchema
+root
+ |-- file_hash: string (nullable = true)
+ |-- content: binary (nullable = true)
+ |-- commit_hash: string (nullable = true)
+ |-- is_binary: boolean (nullable = false)
+ |-- path: string (nullable = true)
+ |-- repository_id: string (nullable = true)
+ |-- name: string (nullable = true)
+
+```

--- a/_examples/scala/spark-shell-schemas.md
+++ b/_examples/scala/spark-shell-schemas.md
@@ -1,3 +1,9 @@
+## Printing schema example
+
+The next example showed,  just try to show the simple usage of the useful method `printSchema`.
+
+It can help you to follow the aggregated or pruned information that your transformations make on the data you are handling.
+
 ```bash
 $ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 scala> import tech.sourced.api._
@@ -13,7 +19,7 @@ root
  |-- is_fork: boolean (nullable = true)
 
 
-scala> api.getRepositories.getReferenceprintSchema
+scala> api.getRepositories.getReference.printSchema
 getReference   getReferences
 
 scala> api.getRepositories.getReferences.printSchema

--- a/_examples/scala/spark-shell-uast-extraction.md
+++ b/_examples/scala/spark-shell-uast-extraction.md
@@ -1,0 +1,38 @@
+```bash
+$ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
+scala> import tech.sourced.api._
+import tech.sourced.api._
+
+scala> val api = SparkAPI(spark, "/path/to/siva-files")
+
+scala> val exampleDf = api.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getFiles.extractUASTs.select('name, 'path, 'uast).where('uast.isNotNull)
+
+scala> exampleDf.show
+
++---------------+--------------------+--------------------+
+|           name|                path|                uast|
++---------------+--------------------+--------------------+
+|refs/heads/HEAD|          .gitignore|                  []|
+|refs/heads/HEAD|         .travis.yml|                  []|
+|refs/heads/HEAD|             LICENSE|                  []|
+|refs/heads/HEAD|           README.md|                  []|
+|refs/heads/HEAD|          abs/abs.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|differentiation/s...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|euclidean/distanc...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|factorial/factori...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|factorial/factori...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|fibonacci/fibonac...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|          gcd/gcd.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|gcd/gcd_optimal_e...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|          lcm/lcm.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|lcm/lcm_optimal_e...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|   prime/is_prime.py|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|prime/is_prime_im...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD|prime/is_prime_op...|[0A 06 4D 6F 64 7...|
+|refs/heads/HEAD| prime/next_prime.py|[0A 06 4D 6F 64 7...|
++---------------+--------------------+--------------------+
+only showing top 20 rows
+
+```

--- a/_examples/scala/spark-shell-uast-extraction.md
+++ b/_examples/scala/spark-shell-uast-extraction.md
@@ -1,3 +1,11 @@
+## Extracting UASTs example
+
+In the example code below, you can take a look to how the `extractUASTs` method works.
+
+From the `api` object instantiated in the spark-shell, a bunch of files has been got filtering repositories by `id`, retrieving their `HEAD` references and requesting for them. Once we have that files, we can call `extractUASTs` which send the files to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
+
+Finally, the reference `name`, file `path` and `uast` is showed on the table.
+
 ```bash
 $ spark-shell --packages com.github.src-d:spark-api:master-SNAPSHOT --repositories https://jitpack.io
 scala> import tech.sourced.api._


### PR DESCRIPTION
I just added a few basic examples for spark, pyspark, and jupyter. I was trying to use `classifyLanguage` and `extractUASTs`functionality but they don't work right now, so I didn't add any example about. I'll try to make it work somehow since https://github.com/src-d/spark-api/pull/57 doesn't work for me.

It would be nice if you could suggest other kind of examples to include, based on some usage  cases. 