### PR TITLE
return all commit files in BlobIterator, implement getFiles in api

### DIFF
--- a/python/sourced/spark/api.py
+++ b/python/sourced/spark/api.py
@@ -12,6 +12,11 @@ class API(object):
     >>> from sourced.spark import API as SparkAPI
     >>> repos_df = SparkAPI(sparkSession, "/path/to/my/repositories").repositories
     >>> repos_df.show()
+
+    :param session: spark session to use
+    :type session: pyspark.sql.SparkSession
+    :param repos_path: path to the folder where siva files are stored
+    :type repos_path: str
     """
 
     def __init__(self, session, repos_path):
@@ -28,17 +33,71 @@ class API(object):
     @property
     def repositories(self):
         """
-        Returns a DataFrame with the repositories available at the given path.
+        Returns a DataFrame with the data about the repositories found at
+        the specified repositories path in the form of siva files.
+
+        >>> repos_df = api.repositories
+
+        :rtype: RepositoriesDataFrame
         """
-        return RepositoriesDataFrame(self.__api.getRepositories(), 
+        return RepositoriesDataFrame(self.__api.getRepositories(),
                                      self.session, self.__implicits)
 
 
-def custom_df_instance(func):
+    @property
+    def files(self, repository_ids=[], reference_names=[], commit_hashes=[]):
+        """
+        Retrieves the files of a list of repositories, reference names and commit hashes.
+        So the result will be a DataFrame of all the files in the given commits that are
+        in the given references that belong to the given repositories.
+
+        NOTE: due to some specifics in the SparkAPI internals, this is way faster than
+        using the DataFrame implicit methods to get the files, although this might change
+        in the near future.
+
+        >>> files_df = api.repositories.filter("is_fork = false")\\
+        >>>     .references.filter("name = 'some ref'")\\
+        >>>     .commits.filter("hash = 'somehash'")
+        >>> # is way slower than
+        >>> files_df_fast = api.files(repo_ids, ref_names, hashes)
+
+        Calling this function with no arguments is the same as:
+
+        >>> api.repositories.references.commits.files
+
+        What makes this method faster than just the example above is the fact of passing
+        repository ids to filter by, so it's recommended to do so. You can pass any number
+        of elements to filter by (including none).
+
+        :param repository_ids: list of repository ids to filter by (optional)
+        :type repository_ids: list of strings
+        :param reference_names: list of reference names to filter by (optional)
+        :type reference_names: list of strings
+        :param commit_hashes: list of hashes to filter by (optional)
+        :type commit_hashes: list of strings
+        :rtype: FilesDataFrame
+        """
+        if not isinstance(repository_ids, list):
+            raise Exception("repository_ids must be a list")
+
+        if not isinstance(reference_names, list):
+            raise Exception("reference_names must be a list")
+
+        if not isinstance(commit_hashes, list):
+            raise Exception("commit_hashes must be a list")
+
+        return FilesDataFrame(self.__api.getFiles(repository_ids,
+                                                  reference_names,
+                                                  commit_hashes),
+                              self.session,
+                              self.__implicits)
+
+
+def _custom_df_instance(func):
     """
     Wraps the resultant DataFrame of the method call with the class of self.
 
-    >>> @custom_df_instance
+    >>> @_custom_df_instance
     >>> def method(self, *args, **kwargs):
     >>>    return ParentClass.method(self, *args, **kwargs)
     """
@@ -57,6 +116,13 @@ class SourcedDataFrame(DataFrame):
     Custom SparkAPI DataFrame that contains some DataFrame overriden methods and utilities.
     This class should not be used directly, please get your SourcedDataFrames using the
     provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
@@ -70,47 +136,47 @@ class SourcedDataFrame(DataFrame):
         return self._implicits.ApiDataFrame(self._jdf)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def checkpoint(self, *args, **kwargs):
         return DataFrame.checkpoint(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def withWatermark(self, *args, **kwargs):
         return DataFrame.withWatermark(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def hint(self, *args, **kwargs):
         return DataFrame.hint(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def limit(self, *args, **kwargs):
         return DataFrame.limit(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def coalesce(self, *args, **kwargs):
         return DataFrame.coalesce(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def repartition(self, *args, **kwargs):
         return DataFrame.repartition(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def distinct(self):
         return DataFrame.distinct(self)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def sample(self, *args, **kwargs):
         return DataFrame.sample(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def sampleBy(self, *args, **kwargs):
         return DataFrame.sampleBy(self, *args, **kwargs)
 
@@ -122,27 +188,27 @@ class SourcedDataFrame(DataFrame):
         return df_list
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def alias(self, *args, **kwargs):
         return DataFrame.alias(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def crossJoin(self, other):
         return DataFrame.crossJoin(self, other)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def join(self, *args, **kwargs):
         return DataFrame.join(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def sortWithinPartitions(self, *args, **kwargs):
         return DataFrame.sortWithinPartitions(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def sort(self, *args, **kwargs):
         return DataFrame.sort(self, *args, **kwargs)
 
@@ -150,97 +216,97 @@ class SourcedDataFrame(DataFrame):
     orderBy = sort
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def describe(self, *args, **kwargs):
         return DataFrame.describe(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def summary(self, *args, **kwargs):
         return DataFrame.summary(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def select(self, *args, **kwargs):
         return DataFrame.select(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def selectExpr(self, *args, **kwargs):
         return DataFrame.selectExpr(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def filter(self, *args, **kwargs):
         return DataFrame.filter(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def union(self, *args, **kwargs):
         return DataFrame.union(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def unionByName(self, *args, **kwargs):
         return DataFrame.unionByName(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def intersect(self, *args, **kwargs):
         return DataFrame.intersect(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def subtract(self, *args, **kwargs):
         return DataFrame.subtract(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def dropDuplicates(self, *args, **kwargs):
         return DataFrame.dropDuplicates(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def dropna(self, *args, **kwargs):
         return DataFrame.dropna(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def fillna(self, *args, **kwargs):
         return DataFrame.fillna(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def replace(self, *args, **kwargs):
         return DataFrame.replace(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def crosstab(self, *args, **kwargs):
         return DataFrame.crosstab(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def freqItems(self, *args, **kwargs):
         return DataFrame.freqItems(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def withColumn(self, *args, **kwargs):
         return DataFrame.withColumn(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def withColumnRenamed(self, *args, **kwargs):
         return DataFrame.withColumnRenamed(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def drop(self, *args, **kwargs):
         return DataFrame.drop(self, *args, **kwargs)
 
 
-    @custom_df_instance
+    @_custom_df_instance
     def toDF(self, *args, **kwargs):
         return DataFrame.toDF(self, *args, **kwargs)
 
@@ -253,6 +319,15 @@ class SourcedDataFrame(DataFrame):
 class RepositoriesDataFrame(SourcedDataFrame):
     """
     DataFrame containing repositories.
+    This class should not be instantiated directly, please get your RepositoriesDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
@@ -263,6 +338,10 @@ class RepositoriesDataFrame(SourcedDataFrame):
     def references(self):
         """
         Returns the joined DataFrame of references and repositories.
+
+        >>> refs_df = repos_df.references
+
+        :rtype: ReferencesDataFrame
         """
         return ReferencesDataFrame(self._api_dataframe.getReferences(),
                                    self._session, self._implicits)
@@ -271,6 +350,15 @@ class RepositoriesDataFrame(SourcedDataFrame):
 class ReferencesDataFrame(SourcedDataFrame):
     """
     DataFrame with references.
+    This class should not be instantiated directly, please get your ReferencesDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
@@ -281,6 +369,10 @@ class ReferencesDataFrame(SourcedDataFrame):
     def head_ref(self):
         """
         Filters the current DataFrame to only contain those rows whose reference is HEAD.
+
+        >>> heads_df = refs_df.head_ref
+
+        :rtype: ReferencesDataFrame
         """
         return self.ref('refs/heads/HEAD')
 
@@ -289,6 +381,10 @@ class ReferencesDataFrame(SourcedDataFrame):
     def master_ref(self):
         """
         Filters the current DataFrame to only contain those rows whose reference is master.
+
+        >>> master_df = refs_df.master_ref
+
+        :rtype: ReferencesDataFrame
         """
         return self.ref('refs/heads/master')
 
@@ -297,6 +393,12 @@ class ReferencesDataFrame(SourcedDataFrame):
         """
         Filters the current DataFrame to only contain those rows whose reference is the given
         reference name.
+
+        >>> heads_df = refs_df.ref('refs/heads/HEAD')
+
+        :param ref: Reference to get
+        :type ref: str
+        :rtype: ReferencesDataFrame
         """
         return ReferencesDataFrame(self.filter(self.name == ref)._jdf,
                                    self._session, self._implicits)
@@ -306,6 +408,10 @@ class ReferencesDataFrame(SourcedDataFrame):
     def commits(self):
         """
         Returns the current DataFrame joined with the commits DataFrame.
+
+        >>> commits_df = refs_df.commits
+
+        :rtype: CommitsDataFrame
         """
         return CommitsDataFrame(self._api_dataframe.getCommits(), self._session, self._implicits)
 
@@ -314,6 +420,10 @@ class ReferencesDataFrame(SourcedDataFrame):
     def files(self):
         """
         Returns this DataFrame joined with the files DataSource.
+
+        >>> files_df = refs_df.files
+
+        :rtype: FilesDataFrame
         """
         return FilesDataFrame(self._api_dataframe.getFiles(), self._session, self._implicits)
 
@@ -321,6 +431,15 @@ class ReferencesDataFrame(SourcedDataFrame):
 class CommitsDataFrame(SourcedDataFrame):
     """
     DataFrame with commits data.
+    This class should not be instantiated directly, please get your CommitsDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
@@ -331,6 +450,10 @@ class CommitsDataFrame(SourcedDataFrame):
     def files(self):
         """
         Returns this DataFrame joined with the files DataSource.
+
+        >>> files_df = commits_df.FilesDataFrame
+
+        :rtype: FilesDataFrame
         """
         return FilesDataFrame(self._api_dataframe.getFiles(), self._session, self._implicits)
 
@@ -338,33 +461,59 @@ class CommitsDataFrame(SourcedDataFrame):
 class FilesDataFrame(SourcedDataFrame):
     """
     DataFrame containing files data.
+    This class should not be instantiated directly, please get your FilesDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
         SourcedDataFrame.__init__(self, jdf, session, implicits)
 
-    
+
     def classify_languages(self):
         """
         Returns a new DataFrame with the language data of any file added to
         its row.
+
+        >>> files_lang_df = files_df.classify_languages
+
+        :rtype: FilesWithLanguageDataFrame
         """
-        return FilesWithLanguageDataFrame(self._api_dataframe.classifyLanguages(), 
+        return FilesWithLanguageDataFrame(self._api_dataframe.classifyLanguages(),
                                           self._session, self._implicits)
 
-                                
+
     def extract_uasts(self):
         """
         Returns a new DataFrame with the parsed UAST data of any file added to
         its row.
+
+        >>> files_df.extract_uasts
+
+        :rtype: UASTsDataFrame
         """
-        return UASTsDataFrame(self._api_dataframe.extractUASTs(), 
+        return UASTsDataFrame(self._api_dataframe.extractUASTs(),
                               self._session, self._implicits)
 
 
 class FilesWithLanguageDataFrame(SourcedDataFrame):
     """
     DataFrame containing files and language data.
+    This class should not be instantiated directly, please get your FilesWithLanguageDataFrame
+    using the provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):
@@ -375,14 +524,27 @@ class FilesWithLanguageDataFrame(SourcedDataFrame):
         """
         Returns a new DataFrame with the parsed UAST data of any file added to
         its row.
+
+        >>> files_lang_df.extract_uasts
+
+        :rtype: UASTsDataFrame
         """
-        return UASTsDataFrame(self._api_dataframe.extractUASTs(), 
+        return UASTsDataFrame(self._api_dataframe.extractUASTs(),
                               self._session, self._implicits)
 
 
 class UASTsDataFrame(SourcedDataFrame):
     """
     DataFrame containing UAST data.
+    This class should not be instantiated directly, please get your UASTsDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
     """
 
     def __init__(self, jdf, session, implicits):

--- a/python/sourced/spark/api.py
+++ b/python/sourced/spark/api.py
@@ -44,7 +44,6 @@ class API(object):
                                      self.session, self.__implicits)
 
 
-    @property
     def files(self, repository_ids=[], reference_names=[], commit_hashes=[]):
         """
         Retrieves the files of a list of repositories, reference names and commit hashes.

--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -114,3 +114,29 @@ class APITestCase(BaseTestCase):
         self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.uast, b"")
+
+
+    def test_api_files(self):
+        rows = self.api.repositories.references.head_ref.commits.sort('hash').limit(10).collect()
+        repos = []
+        hashes = []
+        for row in rows:
+            repos.append(row['repository_id'])
+            hashes.append(row['hash'])
+
+        self.assertEqual(self.api.files(repos, ["refs/heads/HEAD"], hashes).count(), 745)
+
+
+    def test_api_files_repository(self):
+        files = self.api.files(repository_ids=['github.com/xiyou-linuxer/faq-xiyoulinux'])
+        self.assertEqual(files.count(), 20048)
+
+
+    def test_api_files_reference(self):
+        files = self.api.files(reference_names=['refs/heads/develop'])
+        self.assertEqual(files.count(), 404)
+
+
+    def test_api_files_hash(self):
+        files = self.api.files(commit_hashes=['fff7062de8474d10a67d417ccea87ba6f58ca81d'])
+        self.assertEqual(files.count(), 86)

--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -78,15 +78,15 @@ class APITestCase(BaseTestCase):
 
     def test_files(self):
         df = self.api.repositories.references.commits.files
-        self.assertEqual(df.count(), 5275)
+        self.assertEqual(df.count(), 1536360)
         file = df.sort(df.file_hash).limit(1).first()
-        self.assertEqual(file.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
-        self.assertEqual(file.path, 'sequel_core/stress/mem_array_keys.rb')
+        self.assertEqual(file.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        self.assertEqual(file.path, 'spec/database_spec.rb')
 
 
     def test_files_from_refs(self):
         df = self.api.repositories.references.files
-        self.assertEqual(df.count(), 2689)
+        self.assertEqual(df.count(), 19126)
         file = df.sort(df.file_hash).limit(1).first()
         self.assertEqual(file.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
         self.assertEqual(file.path, 'sequel_core/stress/mem_array_keys.rb')
@@ -95,8 +95,8 @@ class APITestCase(BaseTestCase):
     def test_classify_languages(self):
         df = self.api.repositories.references.commits.files
         row = df.sort(df.file_hash).limit(1).classify_languages().first()
-        self.assertEqual(row.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
-        self.assertEqual(row.path, 'sequel_core/stress/mem_array_keys.rb')
+        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.lang, "Ruby")
 
 
@@ -104,13 +104,13 @@ class APITestCase(BaseTestCase):
         df = self.api.repositories.references.commits.files
         row = df.sort(df.file_hash).limit(1).classify_languages()\
             .extract_uasts().first()
-        self.assertEqual(row.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
-        self.assertEqual(row.path, 'sequel_core/stress/mem_array_keys.rb')
+        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.lang, "Ruby")
         self.assertEqual(row.uast, b"")
 
         df = self.api.repositories.references.commits.files
         row = df.sort(df.file_hash).limit(1).extract_uasts().first()
-        self.assertEqual(row.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
-        self.assertEqual(row.path, 'sequel_core/stress/mem_array_keys.rb')
+        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.uast, b"")

--- a/src/main/scala/tech/sourced/api/Schema.scala
+++ b/src/main/scala/tech/sourced/api/Schema.scala
@@ -40,7 +40,9 @@ private[api] object Schema {
   )
 
   val files = StructType(
-    StructField("file_hash", StringType) ::
+    StructField("repository_id", StringType) ::
+      StructField("reference_name", StringType) ::
+      StructField("file_hash", StringType) ::
       StructField("content", BinaryType) ::
       StructField("commit_hash", StringType) ::
       StructField("is_binary", BooleanType, nullable = false) ::

--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -85,6 +85,8 @@ class SparkAPI(session: SparkSession) {
       .filter($"repository_id".isin(repositoryIds: _*))
       .filter($"reference_name".isin(referenceNames: _*))
       .filter($"commit_hash".isin(commitHashes: _*))
+      .drop("repository_id", "reference_name")
+      .distinct
 
     val commitsDf = df.filter($"id".isin(repositoryIds: _*))
       .getReferences.filter($"name".isin(referenceNames: _*))

--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -70,9 +70,19 @@ class SparkAPI(session: SparkSession) {
     * val filesDfFast = api.getFiles(repoIds, refNames, hashes)
     * }}}
     *
-    * @param repositoryIds  List of the repository ids to filter by
-    * @param referenceNames List of reference names to filter by
-    * @param commitHashes   List of commit hashes to filter by
+    * Calling this function with no arguments is the same as:
+    *
+    * {{{
+    * api.getRepositories.getReferences.getCommits.getFiles
+    * }}}
+    *
+    * What makes this method faster than just the example above is the fact of passing
+    * repository ids to filter by, so it's recommended to do so. You can pass any number
+    * of elements to filter by (including none).
+    *
+    * @param repositoryIds  List of the repository ids to filter by (optional)
+    * @param referenceNames List of reference names to filter by (optional)
+    * @param commitHashes   List of commit hashes to filter by (optional)
     * @return [[org.apache.spark.sql.DataFrame]] with files of the given commits, refs and repos.
     */
   def getFiles(repositoryIds: Seq[String] = Seq(),

--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -4,6 +4,8 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+import scala.collection.JavaConversions.asScalaBuffer
+
 /**
   * SparkAPI is the main entry point to all usage of the source{d} spark-api.
   * It has methods to configure all possible configurable options as well as
@@ -128,6 +130,18 @@ class SparkAPI(session: SparkSession) {
 
     filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
   }
+
+  /**
+    * This method is only offered for easier usage from Python.
+    */
+  private[api] def getFiles(repositoryIds: java.util.List[String],
+               referenceNames: java.util.List[String],
+               commitHashes: java.util.List[String]): DataFrame =
+    getFiles(
+      asScalaBuffer(repositoryIds),
+      asScalaBuffer(referenceNames),
+      asScalaBuffer(commitHashes)
+    )
 
   /**
     * Sets the path where the siva files of the repositories are stored.

--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -111,14 +111,15 @@ package object api {
       * @return new DataFrame containing also files data.
       */
     def getFiles: DataFrame = {
-      val filesDf = getDataSource("files", df.sparkSession).drop("repository_id", "reference_name")
+      var filesDf = getDataSource("files", df.sparkSession)
 
       if (df.schema.fieldNames.contains("hash")) {
         val commitsDf = df.drop("tree").distinct()
+        filesDf = filesDf.drop("repository_id", "reference_name")
         filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
       } else {
         checkCols(df, "reference_name")
-        filesDf
+        filesDf.join(df, filesDf("reference_name") === df("name")).drop($"name")
       }
     }
 

--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -103,10 +103,15 @@ package object api {
       * val filesDf = commitsDf.getFiles
       * }}}
       *
+      * Right now this method is very slow. If you are processing a lot of repositories
+      * you might have to consider pre-processing the repositories, references and hashes
+      * and then using [[tech.sourced.api.SparkAPI.getFiles]] to get the files, instead.
+      * This is likely to change in the near future.
+      *
       * @return new DataFrame containing also files data.
       */
     def getFiles: DataFrame = {
-      val filesDf = getDataSource("files", df.sparkSession)
+      val filesDf = getDataSource("files", df.sparkSession).drop("repository_id", "reference_name")
 
       if (df.schema.fieldNames.contains("hash")) {
         val commitsDf = df.drop("tree").distinct()

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -145,9 +145,9 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     val hashes = rows.map(_._2)
 
     val files = SparkAPI(spark, resourcePath)
-      .getFiles(repositories.distinct, List[String]("refs/heads/HEAD"), hashes.distinct)
+      .getFiles(repositories.distinct, List("refs/heads/HEAD"), hashes.distinct)
 
-    assert(files.count == 3)
+    assert(files.count == 745)
   }
 
 }

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -134,6 +134,21 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     assert(count == 1)
   }
 
+  "Get files after reading commits" should "return the correct files" in {
+    val spark = ss
+    val files = SparkAPI(spark, resourcePath).getRepositories.getReferences.getCommits.getFiles
+
+    assert(files.count == 1536360)
+  }
+
+  "Get files without reading commits" should "return the correct files" in {
+    val spark = ss
+    val api = SparkAPI(spark, resourcePath)
+    val files = api.getRepositories.getReferences.getFiles
+
+    assert(files.count == 19126)
+  }
+
   "Get files" should "return the correct files" in {
     val spark = ss
     val api = SparkAPI(spark, resourcePath)

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -150,4 +150,28 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     assert(files.count == 745)
   }
 
+  "Get files by repository" should "return the correct files" in {
+    val spark = ss
+    val files = SparkAPI(spark, resourcePath)
+      .getFiles(repositoryIds = List("github.com/xiyou-linuxer/faq-xiyoulinux"))
+
+    assert(files.count == 20048)
+  }
+
+  "Get files by reference" should "return the correct files" in {
+    val spark = ss
+    val files = SparkAPI(spark, resourcePath)
+      .getFiles(referenceNames = List("refs/heads/develop"))
+
+    assert(files.count == 404)
+  }
+
+  "Get files by commit" should "return the correct files" in {
+    val spark = ss
+    val files = SparkAPI(spark, resourcePath)
+      .getFiles(commitHashes = List("fff7062de8474d10a67d417ccea87ba6f58ca81d"))
+
+    assert(files.count == 86)
+  }
+
 }

--- a/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/api/DefaultSourceSpec.scala
@@ -98,8 +98,8 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
     val count = SparkAPI(spark, resourcePath)
       .getRepositories
-        .getReferences
-        .getCommits
+      .getReferences
+      .getCommits
       .getReference("refs/heads/develop")
       .count()
 
@@ -132,6 +132,22 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
       .select("name").distinct().count()
 
     assert(count == 1)
+  }
+
+  "Get files" should "return the correct files" in {
+    val spark = ss
+    val api = SparkAPI(spark, resourcePath)
+    val df = api.getRepositories.getHEAD.getCommits
+      .sort("hash").limit(10)
+    val rows = df.collect()
+      .map(row => (row.getString(row.fieldIndex("repository_id")), row.getString(row.fieldIndex("hash"))))
+    val repositories = rows.map(_._1)
+    val hashes = rows.map(_._2)
+
+    val files = SparkAPI(spark, resourcePath)
+      .getFiles(repositories.distinct, List[String]("refs/heads/HEAD"), hashes.distinct)
+
+    assert(files.count == 3)
   }
 
 }

--- a/src/test/scala/tech/sourced/api/iterator/BaseRootedRepoIterator.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BaseRootedRepoIterator.scala
@@ -9,14 +9,14 @@ import tech.sourced.api.provider.{RepositoryProvider, SivaRDDProvider}
 import tech.sourced.api.{BaseSivaSpec, BaseSparkSpec}
 
 trait BaseRootedRepoIterator extends Suite with BaseSparkSpec with BaseSivaSpec with Matchers {
+  lazy val prov: SivaRDDProvider = SivaRDDProvider(ss.sparkContext)
+  lazy val rdd: RDD[PortableDataStream] = prov.get(resourcePath)
+
+  lazy val pds: PortableDataStream = rdd.filter(pds => pds.getPath()
+    .contains("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva")).first()
+  lazy val repo: Repository = RepositoryProvider("/tmp").get(pds)
+
   def testIterator(iterator: (Repository) => Iterator[Row], matcher: (Int, Row) => Unit, total: Int, columnsCount: Int): Unit = {
-    val prov: SivaRDDProvider = SivaRDDProvider(ss.sparkContext)
-    val rdd: RDD[PortableDataStream] = prov.get(resourcePath)
-
-    val pds: PortableDataStream = rdd.filter(pds => pds.getPath()
-      .contains("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva")).first()
-    val repo: Repository = RepositoryProvider("/tmp").get(pds)
-
     val ri: Iterator[Row] = iterator(repo)
 
     var count: Int = 0

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -3,11 +3,11 @@ package tech.sourced.api.iterator
 import java.nio.charset.StandardCharsets
 
 import org.scalatest.FlatSpec
-import tech.sourced.api.util.{CompiledFilter, EqualFilter}
+import tech.sourced.api.util.{CompiledFilter, EqualFilter, InFilter}
 
 class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
-  "BlobIterator" should "return all blobs for files at heads of all refs in repository" in {
+  "BlobIterator" should "return all blobs for files at every commit of all refs in repository" in {
     testIterator(
       new BlobIterator(
         Array(
@@ -18,45 +18,33 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "path"
         ), _, Array[CompiledFilter]()), {
         case (0, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
-        case (1, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
-        case (2, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
-        case (3, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
-        case (4, row) =>
           row.getString(0) should be("047b4a9cfea20a4485b5413a8771e98f7aa1a5c7")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/*")
-          row.getString(2) should be("880653c14945dbbc915f1145561ed3df3ebaf168")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/")
+          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
           row.getBoolean(3) should be(false)
           row.getString(4) should be(".gitignore")
+        case (1, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (2, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
 
-        case (i, _) if i > 432 => fail("commits not expected")
+        case (i, _) if i >= 3547 => fail("commits not expected")
         case _ =>
 
-      }, total = 433, columnsCount = 5
+      }, total = 3547, columnsCount = 5
     )
   }
 
 
-  "BlobIterator" should "filter refs" in {
+  "BlobIterator" should "filter refs and return only files in HEAD of the given ref" in {
     val refFilters = Array[CompiledFilter](new EqualFilter("reference_name", "refs/heads/HEAD"))
 
     testIterator(
@@ -81,14 +69,125 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getBoolean(3) should be(false)
           row.getString(4) should be("README.md")
 
-        case (i, _) if i > 3 => fail("commits not expected")
+        case (i, _) if i > 1 => fail("commits not expected")
         case _ =>
 
-      }, total = 4, columnsCount = 5
+      }, total = 2, columnsCount = 5
     )
   }
 
-    "BlobIterator" should "not fail with other, un-supported filters" in {
+  "BlobIterator" should "filter repositories if given" in {
+    val refFilters = Array[CompiledFilter](new EqualFilter("reference_name", "refs/heads/HEAD"))
+
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, refFilters), {
+        case (0, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (1, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+
+        case (i, _) if i > 1 => fail("commits not expected")
+        case _ =>
+
+      }, total = 2, columnsCount = 5
+    )
+  }
+
+  "BlobIterator" should "return only files for given hashes if they are given" in {
+    val refFilters = Array[CompiledFilter](
+      new InFilter("commit_hash", Array(
+        "fff7062de8474d10a67d417ccea87ba6f58ca81d", "a574356dab47de78259713af2f62955408395974"
+      ))
+    )
+
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, refFilters), {
+        case (0, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (1, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+
+        case (i, _) if i > 11 => fail("commits not expected")
+        case _ =>
+
+      }, total = 12, columnsCount = 5
+    )
+  }
+
+  "BlobIterator" should "return only files for given hashes and repos if they are given" in {
+    val refFilters = Array[CompiledFilter](
+      new EqualFilter("repository_id", "github.com/xiyou-linuxer/faq-xiyoulinux"),
+      new InFilter("commit_hash", Array(
+        "fff7062de8474d10a67d417ccea87ba6f58ca81d", "a574356dab47de78259713af2f62955408395974"
+      ))
+    )
+
+    testIterator(
+      new BlobIterator(
+        Array(
+          "file_hash",
+          "content",
+          "commit_hash",
+          "is_binary",
+          "path"
+        ), _, refFilters), {
+        case (0, row) =>
+          row.getString(0) should be("047b4a9cfea20a4485b5413a8771e98f7aa1a5c7")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/")
+          row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be(".gitignore")
+        case (1, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+        case (2, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+
+        case (i, _) if i > 11 => fail("commits not expected")
+        case _ =>
+
+      }, total = 12, columnsCount = 5
+    )
+  }
+
+  "BlobIterator" should "not fail with other, un-supported filters" in {
     val filters = Array[CompiledFilter](new EqualFilter("path", "README"))
 
     testIterator(
@@ -101,7 +200,7 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "path"
         ), _, filters), {
         case _ =>
-      }, total = 433, columnsCount = 5)
-    }
+      }, total = 3547, columnsCount = 5)
+  }
 
 }

--- a/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/BlobIteratorSpec.scala
@@ -15,31 +15,38 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "content",
           "commit_hash",
           "is_binary",
-          "path"
+          "path",
+          "repository_id",
+          "reference_name"
         ), _, Array[CompiledFilter]()), {
         case (0, row) =>
-          row.getString(0) should be("047b4a9cfea20a4485b5413a8771e98f7aa1a5c7")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/")
-          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be(".gitignore")
-        case (1, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
           new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
-          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("LICENSE")
-        case (2, row) =>
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
           new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
-          row.getString(2) should be("22bb7218dc1309114e0678c675a9c3f1e5334e6a")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (2, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
 
-        case (i, _) if i >= 3547 => fail("commits not expected")
+        case (i, _) if i >= 22187 => fail("commits not expected")
         case _ =>
-
-      }, total = 3547, columnsCount = 5
+      }, total = 22187, columnsCount = 7
     )
   }
 
@@ -54,7 +61,9 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "content",
           "commit_hash",
           "is_binary",
-          "path"
+          "path",
+          "repository_id",
+          "reference_name"
         ), _, refFilters), {
         case (0, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
@@ -62,17 +71,35 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
         case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
           new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
           row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("README.md")
-
-        case (i, _) if i > 1 => fail("commits not expected")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (2, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (3, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (i, _) if i > 3 => fail("commits not expected")
         case _ =>
-
-      }, total = 2, columnsCount = 5
+      }, total = 4, columnsCount = 7
     )
   }
 
@@ -86,7 +113,8 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "content",
           "commit_hash",
           "is_binary",
-          "path"
+          "path",
+          "repository_id"
         ), _, refFilters), {
         case (0, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
@@ -94,17 +122,33 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
         case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
           new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
           row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+        case (2, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/mawag/faq-xiyoulinux")
+        case (3, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/mawag/faq-xiyoulinux")
 
-        case (i, _) if i > 1 => fail("commits not expected")
+        case (i, _) if i > 3 => fail("commits not expected")
         case _ =>
 
-      }, total = 2, columnsCount = 5
+      }, total = 4, columnsCount = 6
     )
   }
 
@@ -159,31 +203,47 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "content",
           "commit_hash",
           "is_binary",
-          "path"
+          "path",
+          "repository_id",
+          "reference_name"
         ), _, refFilters), {
         case (0, row) =>
+          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("LICENSE")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (1, row) =>
+          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
+          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getBoolean(3) should be(false)
+          row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/HEAD")
+        case (2, row) =>
           row.getString(0) should be("047b4a9cfea20a4485b5413a8771e98f7aa1a5c7")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea/")
+          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith(".idea")
           row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
           row.getBoolean(3) should be(false)
           row.getString(4) should be(".gitignore")
-        case (1, row) =>
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/develop")
+        case (3, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
           new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("                    GNU GENERAL PUBLIC LICENSE")
           row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
           row.getBoolean(3) should be(false)
           row.getString(4) should be("LICENSE")
-        case (2, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8) should startWith("# faq-xiyoulinux")
-          row.getString(2) should be("a574356dab47de78259713af2f62955408395974")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
+          row.getString(5) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(6) should be("refs/heads/develop")
 
-        case (i, _) if i > 11 => fail("commits not expected")
+        case (i, _) if i >= 412 => fail("commits not expected")
         case _ =>
 
-      }, total = 12, columnsCount = 5
+      }, total = 412, columnsCount = 7
     )
   }
 
@@ -200,7 +260,7 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           "path"
         ), _, filters), {
         case _ =>
-      }, total = 3547, columnsCount = 5)
+      }, total = 22187, columnsCount = 5)
   }
 
 }

--- a/src/test/scala/tech/sourced/api/iterator/CommitIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/api/iterator/CommitIteratorSpec.scala
@@ -3,6 +3,7 @@ package tech.sourced.api.iterator
 import java.sql.Timestamp
 
 import org.scalatest.FlatSpec
+import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
 class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
@@ -165,5 +166,17 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
         case _ =>
       }, total = 1062, columnsCount = 2
     )
+  }
+
+  "refCommits" should "not crash if no refs are given" in {
+    val iter = CommitIterator.refCommits(repo)
+    iter.isEmpty should be(true)
+  }
+
+  "refCommits" should "not return duplicated commits even if refs share commits" in {
+    val refs = repo.getAllRefs.values.asScala.toList
+    val commits = CommitIterator.refCommits(repo, refs: _*).map(c => c.getId.name).toList
+
+    commits.distinct.length should be(commits.length)
   }
 }

--- a/src/test/scala/tech/sourced/api/util/ColumnFilterSpec.scala
+++ b/src/test/scala/tech/sourced/api/util/ColumnFilterSpec.scala
@@ -53,6 +53,15 @@ class ColumnFilterSpec extends FlatSpec with Matchers {
     notEq.eval(Map("test" -> "a", "test2" -> "a")) should be(Some(false))
     notEq.eval(Map("test" -> "b", "test2" -> "a")) should be(Some(true))
     notEq.eval(Map("test2" -> "a")) should be(None)
+
+    val in = new InFilter("test", Array("a", "b", "c"))
+
+    in.matchingCases should be(Map("test" -> Seq("a", "b", "c")))
+
+    in.eval(Map("test" -> "a")) should be(Some(true))
+    in.eval(Map("test" -> "a",  "foo" -> "a")) should be(Some(true))
+    in.eval(Map("test" -> "d")) should be(Some(false))
+    in.eval(Map("foo" -> "b")) should be(None)
   }
 
   "ColumnFilter" should "process correctly columns" in {
@@ -72,7 +81,7 @@ class ColumnFilterSpec extends FlatSpec with Matchers {
   }
 
   "ColumnFilter" should "handle correctly unsupported filters" in {
-    val f = ColumnFilter.compileFilter(In("test", Array("a", "b", "c")))
+    val f = ColumnFilter.compileFilter(StringStartsWith("test", "a"))
 
     f.matchingCases should be(Map())
     f.eval(Map("test" -> "a")) should be(None)


### PR DESCRIPTION
Closes #68 
Closes #62 

BlobIterator now returns the files of each commit of each ref of each repo, instead of just the files on all ref head.

The schema of the files table is also changed to contain repository_id and reference_name so the filters are pushed down to the iterator and some optimizations can be done for the retrieval of just a small amount of files with certain restrictions such
as just retrieving files of a few hashes or references.
That said, this is just a temporary hack until more clever measures are put in place, because now we have two columns that will always be null and will always be dropped from the dataframe just for the sake of getting the filters pushed down.

SparkAPI has now a method `getFiles` to retrieve files given a set of repositories, references and/or hashes which takes advantage of the aforementioned optimizations until a more general approach is implemented by just using the regular dataframe of files.

### Note

This is still a work in progress. A few methods still need to be implemented and lacks a bit of testing, but I sent the PR to start getting feedback specially on the `BlobIterator` side.

CI does not pass yet.