### PR TITLE
[WIP] Add a new rule to avoid unnecessary Joins

### DIFF
--- a/src/main/scala/tech/sourced/api/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/api/DefaultSource.scala
@@ -1,24 +1,30 @@
 package tech.sourced.api
 
-import org.apache.spark.{InterruptibleIterator, SparkException, TaskContext}
+import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import tech.sourced.api.iterator._
 import tech.sourced.api.provider.{RepositoryProvider, SivaRDDProvider}
-import tech.sourced.api.util.ColumnFilter
 
 class DefaultSource extends RelationProvider with DataSourceRegister {
 
-  override def shortName() = "git"
+  override def shortName = "git"
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
     val table = parameters.getOrElse(DefaultSource.tableNameKey, throw new SparkException("parameter 'table' must be provided"))
-    val path = parameters.getOrElse(DefaultSource.pathKey, throw new SparkException("parameter 'path' must be provided"))
-    val localPath = sqlContext.getConf("spark.local.dir", "/tmp")
 
-    GitRelation(sqlContext, table, path, localPath)
+    val schema: StructType = table match {
+      case "repositories" => Schema.repositories
+      case "references" => Schema.references
+      case "commits" => Schema.commits
+      case "files" => Schema.files
+      case other => throw new SparkException(s"table '$other' is not supported")
+    }
+
+    GitRelation(sqlContext, schema, tableSource = Some(table))
   }
 }
 
@@ -27,40 +33,69 @@ object DefaultSource {
   val pathKey = "path"
 }
 
-case class GitRelation(sqlContext: SQLContext, tableName: String, path: String, localPath: String) extends BaseRelation with PrunedFilteredScan {
+case class GitRelation(
+                        sqlContext: SQLContext,
+                        schema: StructType,
+                        joinConditions: Option[Expression] = None,
+                        tableSource: Option[String] = None)
+  extends BaseRelation with CatalystScan {
 
-  override def schema: StructType = tableName match {
-    case "repositories" => Schema.repositories
-    case "references" => Schema.references
-    case "commits" => Schema.commits
-    case "files" => Schema.files
-    case other => throw new SparkException(s"table '$other' is not supported")
+  private val localPath: String = sqlContext.getConf(localPathKey, "/tmp")
+  private val path: String = sqlContext.getConf(repositoriesPathKey)
+  private val skipCleanup: Boolean = sqlContext.sparkContext.getConf.getBoolean(skipCleanupKey, false)
+
+  // TODO implement this correctly to avoid a lot of required columns push up to spark
+  override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
+    super.unhandledFilters(filters)
   }
 
-  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+  override def buildScan(requiredColumns: Seq[Attribute], filters: Seq[Expression]): RDD[Row] = {
+    // TODO remove prints
+    println("JOIN CONDITIONS: ", joinConditions)
+    println("SCHEMA: ", schema)
+    println("SCHEMA METADATA: ", schema.map(_.metadata))
+    println("FILTERS:", filters)
+    println("REQUIRED COLS:", requiredColumns)
+    println("REQUIRED COLS METADATA:", requiredColumns.map(_.metadata))
+    println("PATH AND LOCAL PATH:", path, localPath)
+
+    // TODO process join conditions
+    // TODO process filters
+
+    // get required columns per data source
+    val rc: Map[String, Array[String]] = tableSource match {
+      case Some(ts) => Map(ts -> requiredColumns.map(_.name).toArray)
+      case None =>
+        requiredColumns
+          .map(a => a.metadata.getString("source") -> a.name)
+          .groupBy(_._1).map { case (k, v) => (k, v.map(_._2).toArray) }
+    }
+
     val sc = sqlContext.sparkContext
-
-    val tableB = sc.broadcast(tableName)
-    val requiredB = sc.broadcast(requiredColumns)
-    val localPathB = sc.broadcast(localPath)
-    // TODO broadcast filters
-
     val sivaRDD = SivaRDDProvider(sc).get(path)
-    val skipCleanup = sqlContext.sparkContext.getConf.getBoolean(skipCleanupKey, false)
+
+    val requiredColsB = sc.broadcast(rc)
+    val localPathB = sc.broadcast(localPath)
 
     sivaRDD.flatMap(pds => {
       val provider = RepositoryProvider(localPathB.value, skipCleanup)
       val repo = provider.get(pds)
 
-      val iter = tableB.value match {
-        case "repositories" => new RepositoryIterator(requiredB.value, repo)
-        case "references" => new ReferenceIterator(requiredB.value, repo)
-        case "commits" => new CommitIterator(requiredB.value, repo)
-        case "files" => new BlobIterator(requiredB.value, repo, filters.map(ColumnFilter.compileFilter))
-        case other => throw new SparkException(s"table '$other' is not supported")
+      // TODO send filters to each iterator
+      val iterators = requiredColsB.value.map {
+        case ("repositories", c) => new RepositoryIterator(c, repo)
+        case ("references", c) => new ReferenceIterator(c, repo)
+        case ("commits", c) => new CommitIterator(c, repo)
+        case ("files", c) => new BlobIterator(c, repo, Array())
+        case other => throw new SparkException(s"required cols for '$other' is not supported")
       }
 
-      new CleanupIterator(iter, provider.close(pds.getPath()))
+      if (iterators.size == 1) {
+        new CleanupIterator(iterators.head, provider.close(pds.getPath()))
+      } else {
+        // TODO process each iterator in order to send data to the next one
+        new CleanupIterator(iterators.head, provider.close(pds.getPath()))
+      }
     })
   }
 }

--- a/src/main/scala/tech/sourced/api/GitOptimizer.scala
+++ b/src/main/scala/tech/sourced/api/GitOptimizer.scala
@@ -1,0 +1,147 @@
+package tech.sourced.api
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, EqualTo, Expression, Literal, NamedExpression, Or}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.{Inner, JoinType}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types._
+
+class SquashGitRelationJoin extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
+    // Joins are only applicable per repository, so we can push down completely the Join into the datasource
+    case q@Join(_, _, _, _) =>
+      val jd = GitOptimizer.getJoinData(q)
+      if (!jd.valid) {
+        return q
+      }
+
+      jd match {
+        case JoinData(feo, jc, pe, attributes, Some(sqlc), _) =>
+          val fe = feo.getOrElse(EqualTo(Literal(false, BooleanType), Literal(true, BooleanType)))
+          Project(pe,
+            Filter(fe,
+              LogicalRelation(
+                GitRelation(sqlc, GitOptimizer.attributesToSchema(attributes), jc), attributes, None)))
+        case _ => q
+      }
+  }
+}
+
+case class JoinData(
+                     filterExpression: Option[Expression] = None,
+                     joinCondition: Option[Expression] = None,
+                     projectExpressions: Seq[NamedExpression] = Nil,
+                     attributes: Seq[AttributeReference] = Nil,
+                     sqlContext: Option[SQLContext] = None,
+                     valid: Boolean = false)
+
+object GitOptimizer extends Logging {
+  private val supportedJoinTypes: Seq[JoinType] = Inner :: Nil
+
+  def getJoinData(j: Join): JoinData = {
+    // check if the Join type is supported
+    val supportedJoin = supportedJoinTypes.contains(j.joinType)
+
+    // left and right ends in a GitRelation
+    val leftGitRelOpt = gitRelationOpt(j.left)
+    val rightGitRelOpt = gitRelationOpt(j.right)
+
+    // Not a valid Join to optimize GitRelations
+    if (leftGitRelOpt.isEmpty || rightGitRelOpt.isEmpty || !supportedJoin) {
+      logWarning("Join cannot be optimized. It doesn't have GitRelations in both sides, or the Join type is not supported.")
+      return JoinData()
+    }
+
+    // Check Join conditions. They must be all conditions related with GitRelations
+    val leftReferences = leftGitRelOpt.get.references.baseSet
+    val rightReferences = rightGitRelOpt.get.references.baseSet
+    val joinReferences = j.references.baseSet
+
+    val unsupportedConditions = joinReferences -- leftReferences -- rightReferences
+
+    if (unsupportedConditions.nonEmpty) {
+      logWarning(s"Join cannot be optimized. Obtained unsupported conditions: $unsupportedConditions")
+      return JoinData()
+    }
+
+    // Check if the Join contains all valid Nodes
+    val jd: Seq[JoinData] = j.map {
+      case jm@Join(_, _, _, condition) =>
+        if (jm == j) {
+          JoinData(valid = true, joinCondition = condition)
+        } else {
+          logWarning(s"Join cannot be optimized. Invalid node: $jm")
+          JoinData()
+        }
+      case Filter(cond, _) =>
+        JoinData(Some(cond), valid = true)
+      case Project(namedExpressions, _) =>
+        JoinData(None, projectExpressions = namedExpressions, valid = true)
+      case LogicalRelation(GitRelation(sqlc, _, joinCondition, schemaSource), out, _) =>
+
+        // Add metadata to attributes
+        val processedOut = schemaSource match {
+          case Some(ss) => out
+            .map(_.withMetadata(
+              new MetadataBuilder()
+                .putString("source", ss).build()).asInstanceOf[AttributeReference])
+          case None => out
+        }
+
+        JoinData(None, valid = true, joinCondition = joinCondition, attributes = processedOut, sqlContext = Some(sqlc))
+      case other =>
+        logWarning(s"Join cannot be optimized. Invalid node: $other")
+        JoinData()
+    }
+
+    // Reduce all filter expressions into one
+    jd.reduce((jd1, jd2) => {
+      // get all filter expressions
+      val exprOpt: Option[Expression] = mixExpressions(jd1.filterExpression, jd2.filterExpression, Or)
+      // get all join conditions
+      val joinConditionOpt: Option[Expression] = mixExpressions(jd1.joinCondition, jd2.joinCondition, And)
+
+      // get just one sqlContext if any
+      val sqlcOpt = (jd1.sqlContext, jd2.sqlContext) match {
+        case (Some(l), _) => Some(l)
+        case (_, Some(r)) => Some(r)
+        case _ => None
+      }
+
+      JoinData(
+        exprOpt,
+        joinConditionOpt,
+        jd1.projectExpressions ++ jd2.projectExpressions,
+        jd1.attributes ++ jd2.attributes,
+        sqlcOpt,
+        jd1.valid && jd2.valid
+      )
+    })
+
+  }
+
+  private def mixExpressions(
+                              l: Option[Expression],
+                              r: Option[Expression],
+                              joinFunction: (Expression, Expression) => Expression):
+  Option[Expression] = {
+    (l, r) match {
+      case (Some(expr1), Some(expr2)) => Some(joinFunction(expr1, expr2))
+      case (None, None) => None
+      case (le, None) => le
+      case (None, re) => re
+    }
+  }
+
+  def gitRelationOpt(lp: LogicalPlan): Option[LogicalRelation] =
+    lp.find {
+      case LogicalRelation(GitRelation(_, _, _, _), _, _) => true
+      case _ => false
+    } map (_.asInstanceOf[LogicalRelation])
+
+  def attributesToSchema(attributes: Seq[AttributeReference]): StructType =
+    StructType(attributes.map((a: Attribute) => StructField(a.name, a.dataType, a.nullable, a.metadata)) toArray)
+}

--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -30,6 +30,7 @@ import tech.sourced.api.udf.{ClassifyLanguagesUDF, CustomUDF, ExtractUASTsUDF}
 package object api {
 
   private[api] val repositoriesPathKey = "tech.sourced.api.repositories.path"
+  private[api] val localPathKey = "spark.local.dir"
   private[api] val bblfshHostKey = "tech.sourced.bblfsh.grpc.host"
   private[api] val bblfsPortKey = "tech.sourced.bblfsh.grpc.port"
   private[api] val skipCleanupKey = "tech.sourced.api.cleanup.skip"
@@ -109,7 +110,7 @@ package object api {
       val filesDf = getDataSource("files", df.sparkSession)
 
       if (df.schema.fieldNames.contains("hash")) {
-        val commitsDf = df.drop("tree").distinct()
+        val commitsDf = df.drop("tree")
         filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash")).drop($"hash")
       } else {
         checkCols(df, "reference_name")


### PR DESCRIPTION
Things to do
- Implement unhandledFilters method to just push up the neccessary filters to spark, by default all filters are executed on spark side again. Doing this we avoid too much data on requiredColumns relation value.
- Change ColumnFilter to work with Expressions instead of Filters, because we changed from PrunedFilteredScan relation to CatalystScan relation.
- Add new logic to GitRelation to concatenate iterators depending of the conditions and filters.
- Add a lot of tests to check several use cases.
- Add metadata to attributes to know the source of them (repositories,references,commits,files).