### PR TITLE
Automated docker build and push task in Travis CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Exclude all directories and files except those used by Dockerfile to build the image
+*
+!target/scala-2.11/spark-api-uber.jar
+!examples/
+!python/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,5 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - make push
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       python: 3.6
 
       install:
-        - ./sbt assembly
+        - make build
         - mkdir -p python/jars
         - cp target/**/spark-api-uber.jar python/jars
         - cd python
@@ -67,8 +67,8 @@ before_script:
   - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
 
 script:
-  - ./sbt ++$TRAVIS_SCALA_VERSION scalastyle test test:scalastyle coverage coverageReport
-  - ./sbt ++$TRAVIS_SCALA_VERSION assembly
+  - make travis-test
+  - make build
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       python: 2.7
 
       install:
-        - ./sbt assembly
+        - make build
         - mkdir -p python/jars
         - cp target/**/spark-api-uber.jar python/jars
         - cd python
@@ -72,5 +72,5 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - make push
+  - make docker-push
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Docker
+DOCKER_CMD = docker
+DOCKER_BUILD = $(DOCKER_CMD) build
+DOCKER_TAG ?= $(DOCKER_CMD) tag
+DOCKER_PUSH ?= $(DOCKER_CMD) push
+
+# Docker image tag
+GIT_COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
+GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "-dirty" || true)
+DEV_PREFIX := dev
+VERSION ?= $(DEV_PREFIX)-$(GIT_COMMIT)$(GIT_DIRTY)
+
+# escape_docker_tag escape colon char to allow use a docker tag as rule
+define escape_docker_tag
+$(subst :,--,$(1))
+endef
+
+# unescape_docker_tag an escaped docker tag to be use in a docker command
+define unescape_docker_tag
+$(subst --,:,$(1))
+endef
+
+# if TRAVIS_TAG defined DOCKER_VERSION is overrided
+ifneq ($(TRAVIS_TAG), )
+    VERSION := $(TRAVIS_TAG)
+endif
+
+# if we are not in master, and it's not a tag the push is disabled
+ifneq ($(TRAVIS_BRANCH), master)
+	ifeq ($(TRAVIS_TAG), )
+        pushdisabled = "push disabled for non-master branches"
+	endif
+endif
+
+# if this is a pull request, the push is disabled
+ifneq ($(TRAVIS_PULL_REQUEST), false)
+        pushdisabled = "push disabled for pull-requests"
+endif
+
+DOCKER_IMAGE ?= src-d/spark-api-jupyter
+DOCKER_IMAGE_VERSIONED ?= $(call escape_docker_tag,$(DOCKER_IMAGE):$(VERSION))
+
+# Rules
+all: clean build
+
+clean:
+	./sbt clean
+
+build:
+	./sbt assembly
+
+docker-build: build
+	$(DOCKER_BUILD) -t $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED)) .
+
+push: docker-build
+	$(if $(pushdisabled),$(error $(pushdisabled)))
+
+	@if [ "$$DOCKER_USERNAME" != "" ]; then \
+		$(DOCKER_CMD) login -u="$$DOCKER_USERNAME" -p="$$DOCKER_PASSWORD"; \
+	fi;
+
+	$(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED))
+	@if [ "$$TRAVIS_TAG" != "" ]; then \
+		$(DOCKER_TAG) $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED)) \
+			$(call unescape_docker_tag,$(DOCKER_IMAGE)):latest; \
+		$(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE):latest); \
+	fi;
+

--- a/Makefile
+++ b/Makefile
@@ -57,26 +57,23 @@ endif
 DOCKER_IMAGE ?= src-d/spark-api-jupyter
 DOCKER_IMAGE_VERSIONED ?= $(call escape_docker_tag,$(DOCKER_IMAGE):$(VERSION))
 
+#SBT
+SBT = ./sbt ++$(SCALA_VERSION)
+
 # Rules
 all: clean build
 
 clean:
-	./sbt clean
-
-scalastyle:
-	./sbt scalastyle
+	$(SBT) clean
 
 test:
-	./sbt test
-
-test-scalastyle:
-	./sbt test:scalastyle
-
-test-cover:
-	./sbt ++$(SCALA_VERSION) jacoco:cover
+	$(SBT) test
 
 build:
-	./sbt assembly
+	$(SBT) assembly
+
+travis-test:
+	$(SBT) scalastyle test test:scalastyle coverage coverageReport
 
 docker-build: build
 	$(DOCKER_BUILD) -t $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED)) .

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "-dirty" || true)
 DEV_PREFIX := dev
 VERSION ?= $(DEV_PREFIX)-$(GIT_COMMIT)$(GIT_DIRTY)
 
+# Scala version
+SCALA_VERSION ?= 2.11.11
+
 # escape_docker_tag escape colon char to allow use a docker tag as rule
 define escape_docker_tag
 $(subst :,--,$(1))
@@ -29,9 +32,14 @@ define unescape_docker_tag
 $(subst --,:,$(1))
 endef
 
+# if TRAVIS_SCALA_VERSION defined SCALA_VERSION is overrided
+ifneq ($(TRAVIS_SCALA_VERSION), )
+	SCALA_VERSION := $(TRAVIS_SCALA_VERSION)
+endif
+
 # if TRAVIS_TAG defined VERSION is overrided
 ifneq ($(TRAVIS_TAG), )
-    VERSION := $(TRAVIS_TAG)
+	VERSION := $(TRAVIS_TAG)
 endif
 
 # if we are not in master, and it's not a tag the push is disabled
@@ -63,6 +71,9 @@ test:
 
 test-scalastyle:
 	./sbt test:scalastyle
+
+test-cover:
+	./sbt ++$(SCALA_VERSION) jacoco:cover
 
 build:
 	./sbt assembly

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is written in Scala and built on top of Apache Spark to enable rapid construc
 Current implementation combines:
  - [src-d/enry](https://github.com/src-d/enry) to detect programming language of every file
  - [bblfsh/client-scala](https://github.com/bblfsh/client-scala) to parse every file to UAST
- - [src-d/siva-java](https://github.com/src-d/siva-java) for reading Siva files in JVM 
+ - [src-d/siva-java](https://github.com/src-d/siva-java) for reading Siva files in JVM
  - [apache/spark](https://github.com/apache/spark) to extend DataFrame API
  - [eclipse/jgit](https://github.com/eclipse/jgit) for working with Git .pack files
 
@@ -149,6 +149,14 @@ scala> api.getRepositories.filter('id === "github.com/mawag/faq-xiyoulinux").
 
 ```
 
+# Playing around with spark-api on Jupyter
+
+You can launch our docker container which contains some Notebooks examples just running:
+
+    docker run --name spark-api-jupyter -it --rm -p 8888:8888 -v $(pwd)/path/siva-files:/repositories src-d/spark-api-jupyter
+
+You must have some siva files in local to mount them on the container replacing the path `$(pwd)/path/siva-files`. You can get some siva-files from the project [here](https://github.com/src-d/spark-api/tree/master/src/test/resources/siva-files).
+
 # Development
 
 ## Build fatjar
@@ -163,12 +171,21 @@ It leaves the fatjar in `target/scala-2.11/spark-api-uber.jar`
 
 ## Build and run docker to get a Jupyter server
 
+To build an image with the last built of the project:
+
 ```bash
-$ docker -t spark-api-jupyter .
-$ docker run -p 8888:8888 -v /path/to/siva-files:/repositories spark-api-jupyter
+$ make docker-build
 ```
 
 Notebooks under examples folder will be included on the image.
+
+To build and run a container with the Jupyter server
+
+```bash
+$ make docker-run
+```
+
+Container's output will show you an URL that you can paste on your browser.
 
 ## Run tests
 


### PR DESCRIPTION
I followed the same structure bblfsh use to push the server images.

This PR hasn't been tested because it needs to be merged and tagged on master.

For the moment the image tag is built as `dev-[7 first digits from spark-api HEAD commit]-dirty`

Docker credentials are already set in travis.