### PR TITLE
Change jacoco to scoverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,8 @@ before_script:
   - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
 
 script:
-  - ./sbt scalastyle
-  - ./sbt test:scalastyle
-  - ./sbt ++$TRAVIS_SCALA_VERSION jacoco:cover
-  - ./sbt assembly
+  - ./sbt ++$TRAVIS_SCALA_VERSION scalastyle test test:scalastyle coverage coverageReport
+  - ./sbt ++$TRAVIS_SCALA_VERSION assembly
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import Dependencies.{scalaTest, _}
-import de.johoop.jacoco4sbt.XMLReport
 import sbt.Keys.{libraryDependencies, resolvers}
 
 lazy val root = (project in file(".")).
@@ -11,6 +10,7 @@ lazy val root = (project in file(".")).
     )),
     name := "spark-api",
     libraryDependencies += scalaTest % Test,
+    libraryDependencies += scoverage % Test,
     libraryDependencies += sparkSql % Provided,
     libraryDependencies += newerHadoopClient % Provided, //due to newer v. of guava in bblfsh
     libraryDependencies += fixNettyForGrpc, // grpc for bblfsh/client-scala needs to be newer then in Spark
@@ -25,11 +25,6 @@ lazy val root = (project in file(".")).
     test in assembly := {},
     assemblyJarName in assembly := s"${name.value}-uber.jar"
   )
-
-jacoco.settings
-
-jacoco.reportFormats in jacoco.Config := Seq(
-  XMLReport(encoding = "utf-8"))
 
 parallelExecution in Test := false
 logBuffered in Test := false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
+  lazy val scoverage = "org.scoverage" %% "scalac-scoverage-plugin" % "1.3.1"
   lazy val sparkSql = "org.apache.spark" %% "spark-sql" % "2.2.0"
   lazy val newerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
   lazy val fixNettyForGrpc = "io.netty" % "netty-all" % "4.1.11.Final"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.3.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
Changing from jacoco to scoverage because:

- Jacoco sbt plugin is not working correctly if you want to execute test from Intellij IDE
- Scoverage plugin is more updated than Jacoco one
- Scoverage is the standard to measure coverage on codecov examples

Fixes https://github.com/src-d/spark-api/issues/40