### PR TITLE
Only ejecute docker push on tag creations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,5 +72,10 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - make docker-push
 
+deploy:
+  provider: script
+  script: make docker-push
+  skip_cleanup: true
+  on:
+    tags: true

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ifneq ($(TRAVIS_PULL_REQUEST), false)
         pushdisabled = "push disabled for pull-requests"
 endif
 
-DOCKER_IMAGE ?= src-d/spark-api-jupyter
+DOCKER_IMAGE ?= srcd/spark-api-jupyter
 DOCKER_IMAGE_VERSIONED ?= $(call escape_docker_tag,$(DOCKER_IMAGE):$(VERSION))
 
 #SBT


### PR DESCRIPTION
Download the base image and install all the needed dependencies to build the docker image takes too long to run in every build.
Move the docker build command to deploy phase, to be executed only when a tag is created.