### PR TITLE
docs: remove mentions about getFiles from DataFrame being slow

### DIFF
--- a/src/main/scala/tech/sourced/api/SparkAPI.scala
+++ b/src/main/scala/tech/sourced/api/SparkAPI.scala
@@ -61,18 +61,7 @@ class SparkAPI(session: SparkSession) {
     * the given commits that are in the given references that belong to the given
     * repositories.
     *
-    * NOTE: due to some specifics in the SparkAPI internals, this is way faster than
-    * using the DataFrame implicit methods to get the files, although this might change
-    * in the near future.
-    *
     * {{{
-    * val filesDf = api.getRepositories.filter($"is_fork" === false)
-    *   .getReferences.filter($"name" === "some ref")
-    *   .getCommits.filter($"hash" === "some hash")
-    *   .getFiles
-    *
-    * // is way slower than
-    *
     * val filesDfFast = api.getFiles(repoIds, refNames, hashes)
     * }}}
     *
@@ -81,10 +70,6 @@ class SparkAPI(session: SparkSession) {
     * {{{
     * api.getRepositories.getReferences.getCommits.getFiles
     * }}}
-    *
-    * What makes this method faster than just the example above is the fact of passing
-    * repository ids to filter by, so it's recommended to do so. You can pass any number
-    * of elements to filter by (including none).
     *
     * @param repositoryIds  List of the repository ids to filter by (optional)
     * @param referenceNames List of reference names to filter by (optional)

--- a/src/main/scala/tech/sourced/api/package.scala
+++ b/src/main/scala/tech/sourced/api/package.scala
@@ -131,6 +131,23 @@ package object api {
         .drop(refsIdsDf("name")).drop(refsIdsDf("repository_id"))
     }
 
+    /**
+      * Returns a new [[org.apache.spark.sql.DataFrame]] with only the first commit in a reference.
+      * Without calling this method, commits may appear multiple times in your [[DataFrame]],
+      * because most of your commits will be shared amongst references. Calling this, your
+      * [[DataFrame]] will only contain the HEAD commit of each reference.
+      *
+      * For the next example, consider we have a master branch with 100 commits and a "foo" branch
+      * whose parent is the HEAD of master and has two more commits.
+      * {{{
+      * > commitsDf.count()
+      * 202
+      * > commitsDf.getFirstReferenceCommit.count()
+      * 2
+      * }}}
+      *
+      * @return dataframe with only the HEAD commits of each reference
+      */
     def getFirstReferenceCommit: DataFrame = {
       checkCols(df, "index")
       df.filter($"index" === 0)
@@ -139,17 +156,10 @@ package object api {
     /**
       * Returns a new [[org.apache.spark.sql.DataFrame]] with the product of joining the
       * current dataframe with the files dataframe.
-      * It requires the current dataframe to have a "files" column, which is are the
-      * files of a commit.
       *
       * {{{
       * val filesDf = commitsDf.getFiles
       * }}}
-      *
-      * Right now this method is very slow. If you are processing a lot of repositories
-      * you might have to consider pre-processing the repositories, references and hashes
-      * and then using [[tech.sourced.api.SparkAPI.getFiles]] to get the files, instead.
-      * This is likely to change in the near future.
       *
       * @return new DataFrame containing also files data.
       */


### PR DESCRIPTION
Also adds docs to `getFirstReferenceCommit`