### PR TITLE
Use bblfshd and fix documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV SRCD_JAR /opt/jars/spark-api-uber.jar
 
 # bblfsh endpoint variables
 ENV SPARK_BBLFSH_HOST spark.tech.sourced.bblfsh.grpc.host
-ENV BBLFSH_HOST bblfsh
+ENV BBLFSH_HOST bblfshd
 ENV SPARK_BBLFSH_PORT spark.tech.sourced.bblfsh.grpc.port
 ENV BBLFSH_PORT 9432
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ ./bin/spark-shell --packages "com.github.src-d:spark-api:master-SNAPSHOT" --re
 $ ./bin/pyspark --repositories "https://jitpack.io"  --packages "com.github.src-d:spark-api:master-SNAPSHOT"
 ```
 
-Run [bblfsh server](https://github.com/bblfsh/server):
+Run [bblfsh daemon](https://github.com/bblfsh/bblfshd):
 
     docker run --rm --privileged -p 9432:9432 --name bblfsh bblfsh/server:v1.2.0 bblfsh server --log-level="debug"
 
@@ -58,7 +58,7 @@ $ $SPARK_HOME/bin/spark-shell
 
 ## bblfsh
 
-If you want to be able to use the UAST extraction features spark-api provides, you must run a Run [bblfsh server](https://github.com/bblfsh/server). You can do it easily with docker
+If you want to be able to use the UAST extraction features spark-api provides, you must run a [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can do it easily with docker
 
     docker run --rm --privileged -p 9432:9432 --name bblfsh bblfsh/server:v1.2.0 bblfsh server --log-level="debug"
 
@@ -164,11 +164,11 @@ scala> api.getRepositories.filter('id === "github.com/mawag/faq-xiyoulinux").
 
 You can launch our docker container which contains some Notebooks examples just running:
 
-    docker run --name spark-api-jupyter --rm -it -p 8888:8888 -v $(pwd)/path/to/siva-files:/repositories --link bblfsh:bblfsh src-d/spark-api-jupyter
+    docker run --name spark-api-jupyter --rm -it -p 8888:8888 -v $(pwd)/path/to/siva-files:/repositories --link bblfsh:bblfsh srcd/spark-api-jupyter
 
 You must have some siva files in local to mount them on the container replacing the path `$(pwd)/path/to/siva-files`. You can get some siva-files from the project [here](https://github.com/src-d/spark-api/tree/master/examples/siva-files).
 
-You should have a [bblfsh server](https://github.com/bblfsh/server) container running to link the jupyter container (see Pre-requisites).
+You should have a [bblfsh daemon](https://github.com/bblfsh/bblfshd) container running to link the jupyter container (see Pre-requisites).
 
 When the spark-api-jupyter container starts it will show you an URL that you can open in your browser.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ $ ./bin/pyspark --repositories "https://jitpack.io"  --packages "com.github.src-
 
 Run [bblfsh daemon](https://github.com/bblfsh/bblfshd):
 
-    docker run --rm --privileged -p 9432:9432 --name bblfsh bblfsh/server:v1.2.0 bblfsh server --log-level="debug"
+    docker run --rm --name bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:v2.0.0
+
+Install bblfsh drivers:
+
+    docker exec -it bblfshd bblfshctl driver install --all
 
 # Pre-requisites
 
@@ -60,9 +64,16 @@ $ $SPARK_HOME/bin/spark-shell
 
 If you want to be able to use the UAST extraction features spark-api provides, you must run a [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can do it easily with docker
 
-    docker run --rm --privileged -p 9432:9432 --name bblfsh bblfsh/server:v1.2.0 bblfsh server --log-level="debug"
+    docker run --rm --name bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:v2.0.0
 
-The first time the server receives a language it didn't process before, it will download the properly driver to parse the file, so it could take a bit time. Once it has the drivers it will run fast.
+Then you need to install bblfsh drivers to parse different languages, you should do this the first time you run the [bblfsh daemon](https://github.com/bblfsh/bblfshd):
+
+    docker exec -it bblfshd bblfshctl driver install --all
+
+You should be able to see the installed drivers running:
+
+    docker exec -it bblfshd bblfshctl driver list
+
 
 # Examples of API usage
 
@@ -200,10 +211,22 @@ To run a container with the Jupyter server:
 $ make docker-run
 ```
 
-Before run the jupyter container you must run a bblfsh server:
+Before run the jupyter container you must run a [bblfsh daemon](https://github.com/bblfsh/bblfshd):
 
 ```bash
 $ make docker-bblfsh
+```
+
+If it's the first time you run the [bblfsh daemon](https://github.com/bblfsh/bblfshd), you must install the drivers:
+
+```bash
+$ make docker-bblfsh-install-drivers
+```
+
+To see installed drivers:
+
+```bash
+$ make docker-bblfsh-list-drivers
 ```
 
 To remove the development jupyter image generated:


### PR DESCRIPTION
#### This PR address issues https://github.com/src-d/spark-api/issues/91 and https://github.com/src-d/spark-api/issues/90.

- Now the image and the Makefile make use of `bblfshd`
- There are new rules `make docker-bblfsh-install-drivers` and `make docker-bblfsh-list-drivers`to make easy `bblfshd` usage.

The current notebook example fails in the last commands because of selecting `repository_id` and `reference_name` columns. I assume this will be fixed in https://github.com/src-d/spark-api/issues/92.

The rest of modifications are tested in my local machine and seem to work well.