### PR TITLE
UAST extraction example in notebook

### DIFF
--- a/_examples/notebooks/Basic+Example.ipynb
+++ b/_examples/notebooks/Basic+Example.ipynb
@@ -2,154 +2,154 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from sourced.spark import API as SparkAPI\n",
+    "from sourced.spark import API as Engine\n",
     "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql.functions import *\n",
     "\n",
     "spark = SparkSession.builder\\\n",
-    ".master(\"local\").appName(\"Examples\")\\\n",
+    ".master(\"local[*]\").appName(\"Examples\")\\\n",
     ".getOrCreate()\n",
     "\n",
-    "api = SparkAPI(spark, \"/repositories\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "repositories_df = api.repositories\n",
-    "references_df = repositories_df.references\n",
-    "commits_df = references_df.commits\n",
-    "files_df = commits_df.files"
+    "engine = Engine(spark, \"/repositories\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get all HEAD references for all the repositories"
+    "### Count the total of non-fork repositories"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "heads_df = references_df.head_ref"
+    "engine.repositories.filter(\"is_fork = false\")\\\n",
+    ".select(\"id\").distinct()\\\n",
+    ".agg(count(\"*\").alias(\"count\"))\\\n",
+    ".select(\"count\").show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get repositories that are marked as no forks"
+    "### Get all the files of all head commits"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "no_forks_df = repositories_df.filter(repositories_df.is_fork == 0)"
+    "head_files = engine.repositories.filter(\"is_fork = false\").references\\\n",
+    ".head_ref.commits.first_reference_commit\\\n",
+    ".files\\\n",
+    ".classify_languages()\\\n",
+    ".filter(\"is_binary = false\")\\\n",
+    ".select(\"file_hash\", \"path\", \"content\", \"lang\").filter(\"lang is not null\").cache()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get only references for original repositories"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "no_forks_heads_df = heads_df.join(no_forks_df, heads_df.repository_id == no_forks_df.id).drop('repository_id').distinct()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "head_commits_df = no_forks_heads_df.join(commits_df, no_forks_heads_df.hash == commits_df.hash)"
+    "### Get the schema"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+---------------+--------------------+--------------------+--------------------+-------+\n",
-      "|           name|                hash|                  id|                urls|is_fork|\n",
-      "+---------------+--------------------+--------------------+--------------------+-------+\n",
-      "|refs/heads/HEAD|fff7062de8474d10a...|github.com/xiyou-...|[git://github.com...|  false|\n",
-      "|refs/heads/HEAD|dbfab055c70379219...|github.com/waynee...|[git://github.com...|  false|\n",
-      "|refs/heads/HEAD|202ceb4d3efd22945...|anongit.kde.org/s...|[https://anongit....|  false|\n",
-      "|refs/heads/HEAD|2060ee6252a64337c...|anongit.kde.org/p...|[https://anongit....|  false|\n",
-      "+---------------+--------------------+--------------------+--------------------+-------+\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "no_forks_heads_df.show()"
+    "head_files.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Print result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head_files.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Top languages per number of files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top_ten_langs = head_files.distinct()\\\n",
+    ".groupBy(\"lang\").agg(count(\"*\").alias(\"count\"))\\\n",
+    ".orderBy(\"count\").sort(desc(\"count\")).limit(20)\\\n",
+    ".show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Get all Java files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " head_files.groupBy(\"lang\").agg(count(\"*\").alias(\"count\")).filter(\"lang='Java'\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Extract UASTs from all those files classfied as Python files in HEAD references"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
-    "head_commits_df.drop(\"blobs\").drop(\"files\").show()"
+    "head_files.where('lang = \"Python\"').extract_uasts().select('file_hash', 'path', 'lang', 'uast').limit(10).show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "files_df.limit(20).show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/examples/notebooks/Basic+Example.ipynb
+++ b/examples/notebooks/Basic+Example.ipynb
@@ -3,12 +3,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from sourced.spark import API as SparkAPI\n",
+    "from sourced.spark import API as Engine\n",
     "from pyspark.sql import SparkSession\n",
     "from pyspark.sql.functions import *\n",
     "\n",
@@ -16,7 +14,7 @@
     ".master(\"local[*]\").appName(\"Examples\")\\\n",
     ".getOrCreate()\n",
     "\n",
-    "api = SparkAPI(spark, \"/repositories\")"
+    "engine = Engine(spark, \"/repositories\")"
    ]
   },
   {
@@ -32,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "api.repositories.filter(\"is_fork = false\")\\\n",
+    "engine.repositories.filter(\"is_fork = false\")\\\n",
     ".select(\"id\").distinct()\\\n",
     ".agg(count(\"*\").alias(\"count\"))\\\n",
     ".select(\"count\").show()"
@@ -48,17 +46,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "head_files = api.repositories.filter(\"is_fork = false\").references\\\n",
-    ".head_ref.commits.filter(\"index = 0\")\\\n",
+    "head_files = engine.repositories.filter(\"is_fork = false\").references\\\n",
+    ".head_ref.commits.first_reference_commit\\\n",
     ".files\\\n",
     ".classify_languages()\\\n",
     ".filter(\"is_binary = false\")\\\n",
-    ".select(\"lang\",\"file_hash\").filter(\"lang is not null\").cache()"
+    ".select(\"file_hash\", \"path\", \"content\", \"lang\").filter(\"lang is not null\").cache()"
    ]
   },
   {
@@ -131,11 +127,29 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
+   "source": [
+    "### Extract UASTs from all those files classfied as Python files in HEAD references"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "head_files.where('lang = \"Python\"').extract_uasts().select('file_hash', 'path', 'lang', 'uast').limit(10).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
- Added the following example to the notebook:

`head_files.where('lang = "Python"').extract_uasts().select('file_hash', 'path', 'lang', 'uast').limit(10).show()`

```
+--------------------+--------------------+------+--------------------+
|           file_hash|                path|  lang|                uast|
+--------------------+--------------------+------+--------------------+
|22df25a3d87c3147e...|       dec_to_hex.py|Python|[0A 06 4D 6F 64 7...|
|859b78bb87c0f7f67...|youtube-downloade...|Python|[0A 06 4D 6F 64 7...|
|ff4fa0794274a7ffb...|fibonacci/fibonac...|Python|[0A 06 4D 6F 64 7...|
|73af2324d76e5e9c1...|powerdown_startup.py|Python|[0A 06 4D 6F 64 7...|
|5b313b2ae75e522e1...| password_cracker.py|Python|[0A 06 4D 6F 64 7...|
|522143e341780459b...|sqlite_table_chec...|Python|[0A 06 4D 6F 64 7...|
|872689447c04c85dd...|        nmap_scan.py|Python|[0A 06 4D 6F 64 7...|
|8ff8834d799fdb36a...|           osinfo.py|Python|[0A 06 4D 6F 64 7...|
|586686d066848def5...|    GroupSms_Way2.py|Python|[0A 06 4D 6F 64 7...|
|4588c749c03e740ec...|        testlines.py|Python|[0A 06 4D 6F 64 7...|
+--------------------+--------------------+------+--------------------+
```

- In `Get all the files of all head commits` snippet `filter("index = 0")` has been changed by `first_reference_commit`
- Import `as SparkAPI` changed to `as Engine`. The object `api` has been changed to `engine` too.